### PR TITLE
Add default description for the `id` field.

### DIFF
--- a/schemamd/render.go
+++ b/schemamd/render.go
@@ -59,6 +59,10 @@ func writeAttribute(w io.Writer, path []string, att *tfjson.SchemaAttribute) ([]
 		return nil, err
 	}
 
+	if name == "id" {
+		att.Description = "The ID of this resource."
+	}
+
 	err = WriteAttributeDescription(w, att)
 	if err != nil {
 		return nil, err

--- a/schemamd/render.go
+++ b/schemamd/render.go
@@ -59,7 +59,7 @@ func writeAttribute(w io.Writer, path []string, att *tfjson.SchemaAttribute) ([]
 		return nil, err
 	}
 
-	if name == "id" {
+	if name == "id" && att.Description == "" {
 		att.Description = "The ID of this resource."
 	}
 


### PR DESCRIPTION
Terraform SDK will inject an `id` field to the provider schema without
setting its description. This PR adds a default description.