### PR TITLE
Add ability to specify generic resources and data source templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ The generation of missing documentation is based on a number of assumptions / co
 | `templates/`                                              | Root of templated docs          |
 | `templates/index.md[.tmpl]`                               | Docs index page (or template)   |
 | `examples/provider/provider.tf`                           | Provider example config*        |
+| `templates/data-sources.md[.tmpl]`                        | Generic data source page (or template)  |
 | `templates/data-sources/<data source name>.md[.tmpl]`     | Data source page (or template)  |
 | `examples/data-sources/<data source name>/data-source.tf` | Data source example config*     |
+| `templates/resources.md[.tmpl]`                           | Generic resource page (or template)     |
 | `templates/resources/<resource name>.md[.tmpl]`           | Resource page (or template)     |
 | `examples/resources/<resource name>/resource.tf`          | Resource example config*        |
 | `examples/resources/<resource name>/import.sh`            | Resource example import command |

--- a/schemamd/render.go
+++ b/schemamd/render.go
@@ -36,7 +36,7 @@ var (
 	groupFilters = []groupFilter{
 		{"### Required", "Required:", childIsRequired},
 		{"### Optional", "Optional:", childIsOptional},
-		{"### Read-only", "Read-only:", childIsReadOnly},
+		{"### Read-Only", "Read-Only:", childIsReadOnly},
 	}
 )
 
@@ -52,7 +52,7 @@ type nestedType struct {
 func writeAttribute(w io.Writer, path []string, att *tfjson.SchemaAttribute, group groupFilter) ([]nestedType, error) {
 	name := path[len(path)-1]
 
-	_, err := io.WriteString(w, "- **"+name+"** ")
+	_, err := io.WriteString(w, "- `"+name+"` ")
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func writeAttribute(w io.Writer, path []string, att *tfjson.SchemaAttribute, gro
 func writeBlockType(w io.Writer, path []string, block *tfjson.SchemaBlockType) ([]nestedType, error) {
 	name := path[len(path)-1]
 
-	_, err := io.WriteString(w, "- **"+name+"** ")
+	_, err := io.WriteString(w, "- `"+name+"` ")
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ func writeNestedTypes(w io.Writer, nestedTypes []nestedType) error {
 func writeObjectAttribute(w io.Writer, path []string, att cty.Type, group groupFilter) ([]nestedType, error) {
 	name := path[len(path)-1]
 
-	_, err := io.WriteString(w, "- **"+name+"** (")
+	_, err := io.WriteString(w, "- `"+name+"` (")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #30

# Background

Templates folder can now contain `resources.md.tmpl` or `data-srouces.md.tmpl`. These are generic template for resources and/or data sources without the need to specify per-resource/data-source template. 

# Usecase

Need for a generic template for resources and data sources. 