### PR TITLE
Fix title and reference links of nested blocks/attributes

### DIFF
--- a/schemamd/render.go
+++ b/schemamd/render.go
@@ -192,7 +192,9 @@ func writeBlockChildren(w io.Writer, parents []string, block *tfjson.SchemaBlock
 		}
 
 		for _, name := range sortedNames {
-			path := append(parents, name)
+			path := make([]string, len(parents), len(parents)+1)
+			copy(path, parents)
+			path = append(path, name)
 
 			if block, ok := block.NestedBlocks[name]; ok {
 				nt, err := writeBlockType(w, path, block)


### PR DESCRIPTION
The `path` slice needs to be made a copy of the `parents`, otherwise when there is enough nesting, the `append` operation does not do a copy of the slice, and we keep modifying the same reference in the nested blocks, thus generating incorrect titles and links.

As an example, you can check https://registry.terraform.io/providers/DataDog/datadog/2.25.0/docs/resources/dashboard#nestedblock--widget--change_definition--request--apm_query, which is the level of nesting things start to go bad. The title shows the wrong `path`, but the anchor ID is still ok at this point.

Related issue: https://github.com/DataDog/terraform-provider-datadog/issues/1024