### PR TITLE
Add "split" template function for use with strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 0.8.0 (April 25, 2022)
+# 0.8.0 (UNRELEASED)
 
 ENHANCEMENTS:
 
-* template functions: Added the `split` command to split a string into substrings
+* template functions: Added `split` to help separating a string into substrings ([#70](https://github.com/hashicorp/terraform-plugin-docs/pull/70)).
  
 # 0.7.0 (March 15, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.8.0 (April 25, 2002)
+# 0.8.0 (April 25, 2022)
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
+# 0.8.0 (April 25, 2002)
+
+ENHANCEMENTS:
+
+* template functions: Added the `split` command to split a string into substrings
+ 
 # 0.7.0 (March 15, 2022)
 
 ENHANCEMENTS:
 
 * cmd/tfplugindocs: Use existing Terraform CLI binary if available on PATH, otherwise download latest Terraform CLI binary (https://github.com/hashicorp/terraform-plugin-docs/pull/124)
 * cmd/tfplugindocs: Added `tf-version` flag for specifying Terraform CLI binary version to download, superseding the PATH lookup (https://github.com/hashicorp/terraform-plugin-docs/pull/124)
-* template functions: Added the `split` command to split a string into substrings
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ ENHANCEMENTS:
 
 * cmd/tfplugindocs: Use existing Terraform CLI binary if available on PATH, otherwise download latest Terraform CLI binary (https://github.com/hashicorp/terraform-plugin-docs/pull/124)
 * cmd/tfplugindocs: Added `tf-version` flag for specifying Terraform CLI binary version to download, superseding the PATH lookup (https://github.com/hashicorp/terraform-plugin-docs/pull/124)
+* template functions: Added the `split` command to split a string into substrings
 
 BUG FIXES:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ TBD
 | `tffile`        | A special case of the `codefile` function. In addition this will elide lines with an `OMIT` comment.               |
 | `trimspace`     | `strings.TrimSpace`                                                                                                |
 | `plainmarkdown` | Render Markdown content as plaintext                                                                               |
+| `split`         | Split string into sub-strings, eg. `split .Name "_"`                                                               |
 
 ### Installation
 

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -40,6 +40,7 @@ func newTemplate(name, text string) (*template.Template, error) {
 			return tmplfuncs.CodeFile("terraform", file)
 		},
 		"trimspace": strings.TrimSpace,
+		"split":     strings.Split,
 	}))
 
 	var err error


### PR DESCRIPTION
This is an excellent piece of tooling that we are finding very helpful
as we develop a new HPE GreenLake provider (called hpegl) that we will
publish to the Provider Registry.  We're using this tool to generate
documentation.  We'd like the ability to set the "subcategory" field in
the resource and data-source templates.  Our provider will support a
number of different services and the naming will be the following:

  hpegl_< service mnemonic >_< service resource or data-source >

We want to extract the service mnemonic from the name and add that as a
"subcategory".  I've added a "split" template function which is set to
strings.Split.  With this template function I can add the following to a
template:

  subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1  }}"

To extract the service mnemonic from the name.  This would be very
helpful to us as we generate documentation.

In addition I've added .idea and vendor to .gitignore.