### PR TITLE
generate: move configuration to flags

### DIFF
--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -11,6 +11,14 @@ type generateCmd struct {
 	commonCmd
 
 	flagLegacySidebar bool
+
+	flagProviderName         string
+	flagRenderedProviderName string
+
+	flagRenderedWebsiteDir string
+	flagExamplesDir        string
+	flagWebsiteTmpDir      string
+	flagWebsiteSourceDir   string
 }
 
 func (cmd *generateCmd) Synopsis() string {
@@ -24,6 +32,12 @@ func (cmd *generateCmd) Help() string {
 func (cmd *generateCmd) Flags() *flag.FlagSet {
 	fs := flag.NewFlagSet("generate", flag.ExitOnError)
 	fs.BoolVar(&cmd.flagLegacySidebar, "legacy-sidebar", false, "generate the legacy .erb sidebar file")
+	fs.StringVar(&cmd.flagProviderName, "provider-name", "", "provider name used for looking up the schema")
+	fs.StringVar(&cmd.flagRenderedProviderName, "rendered-provider-name", "", "provider name used in generated outputs such as page titles")
+	fs.StringVar(&cmd.flagRenderedWebsiteDir, "rendered-website-dir", "docs", "directory where the rendered website documentation is generated to")
+	fs.StringVar(&cmd.flagExamplesDir, "examples-dir", "examples", "directory of examples used in rendered documentation")
+	fs.StringVar(&cmd.flagWebsiteTmpDir, "website-temp-dir", "", "")
+	fs.StringVar(&cmd.flagWebsiteSourceDir, "website-source-dir", "templates", "directory of templates that are used for generating the static output")
 	return fs
 }
 
@@ -39,7 +53,16 @@ func (cmd *generateCmd) Run(args []string) int {
 }
 
 func (cmd *generateCmd) runInternal() error {
-	err := provider.Generate(cmd.ui, cmd.flagLegacySidebar)
+	err := provider.Generate(
+		cmd.ui,
+		cmd.flagLegacySidebar,
+		cmd.flagProviderName,
+		cmd.flagRenderedProviderName,
+		cmd.flagRenderedWebsiteDir,
+		cmd.flagExamplesDir,
+		cmd.flagWebsiteTmpDir,
+		cmd.flagWebsiteSourceDir,
+	)
 	if err != nil {
 		return fmt.Errorf("unable to generate website: %w", err)
 	}

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -16,25 +16,12 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-// TODO: convert these to flags?
 var (
-	providerName string
-
-	// rendered website dir
-	renderedWebsiteDir = "docs"
-
-	// examples directory defaults
-	examplesDir = "examples"
-	// relative to examples dir
 	examplesResourceFileTemplate   = resourceFileTemplate("resources/{{.Name}}/resource.tf")
 	examplesResourceImportTemplate = resourceFileTemplate("resources/{{.Name}}/import.sh")
 	examplesDataSourceFileTemplate = resourceFileTemplate("data-sources/{{ .Name }}/data-source.tf")
 	examplesProviderFileTemplate   = providerFileTemplate("provider/provider.tf")
 
-	// templated website directory defaults
-	websiteTmp = ""
-
-	websiteSourceDir                    = "templates" // used for override content
 	websiteResourceFileTemplate         = resourceFileTemplate("resources/{{ .ShortName }}.md.tmpl")
 	websiteResourceFallbackFileTemplate = resourceFileTemplate("resources.md.tmpl")
 	websiteResourceFileStatic           = []resourceFileTemplate{
@@ -73,6 +60,13 @@ var (
 type generator struct {
 	legacySidebar bool
 
+	providerName         string
+	renderedProviderName string
+	renderedWebsiteDir   string
+	examplesDir          string
+	websiteTmpDir        string
+	websiteSourceDir     string
+
 	ui cli.Ui
 }
 
@@ -84,9 +78,16 @@ func (g *generator) warnf(format string, a ...interface{}) {
 	g.ui.Warn(fmt.Sprintf(format, a...))
 }
 
-func Generate(ui cli.Ui, legacySidebar bool) error {
+func Generate(ui cli.Ui, legacySidebar bool, providerName, renderedProviderName, renderedWebsiteDir, examplesDir, websiteTmpDir, websiteSourceDir string) error {
 	g := &generator{
 		legacySidebar: legacySidebar,
+
+		providerName:         providerName,
+		renderedProviderName: renderedProviderName,
+		renderedWebsiteDir:   renderedWebsiteDir,
+		examplesDir:          examplesDir,
+		websiteTmpDir:        websiteTmpDir,
+		websiteSourceDir:     websiteSourceDir,
 
 		ui: ui,
 	}
@@ -104,34 +105,39 @@ func (g *generator) Generate(ctx context.Context) error {
 		return err
 	}
 
-	if providerName == "" {
+	providerName := g.providerName
+	if g.providerName == "" {
 		providerName = filepath.Base(wd)
 	}
 
-	g.infof("rendering website for provider %q", providerName)
+	if g.renderedProviderName == "" {
+		g.renderedProviderName = providerName
+	}
+
+	g.infof("rendering website for provider %q (as %q)", providerName, g.renderedProviderName)
 
 	switch {
-	case websiteTmp == "":
-		websiteTmp, err = ioutil.TempDir("", "tfws")
+	case g.websiteTmpDir == "":
+		g.websiteTmpDir, err = ioutil.TempDir("", "tfws")
 		if err != nil {
 			return err
 		}
-		defer os.RemoveAll(websiteTmp)
+		defer os.RemoveAll(g.websiteTmpDir)
 	default:
-		g.infof("cleaning tmp dir %q", websiteTmp)
-		err = os.RemoveAll(websiteTmp)
+		g.infof("cleaning tmp dir %q", g.websiteTmpDir)
+		err = os.RemoveAll(g.websiteTmpDir)
 		if err != nil {
 			return err
 		}
 
-		g.infof("creating tmp dir %q", websiteTmp)
-		err = os.MkdirAll(websiteTmp, 0755)
+		g.infof("creating tmp dir %q", g.websiteTmpDir)
+		err = os.MkdirAll(g.websiteTmpDir, 0755)
 		if err != nil {
 			return err
 		}
 	}
 
-	websiteSourceDirInfo, err := os.Stat(websiteSourceDir)
+	websiteSourceDirInfo, err := os.Stat(g.websiteSourceDir)
 	switch {
 	case os.IsNotExist(err):
 		// do nothing, no template dir
@@ -139,11 +145,11 @@ func (g *generator) Generate(ctx context.Context) error {
 		return err
 	default:
 		if !websiteSourceDirInfo.IsDir() {
-			return fmt.Errorf("template path is not a directory: %s", websiteSourceDir)
+			return fmt.Errorf("template path is not a directory: %s", g.websiteSourceDir)
 		}
 
 		g.infof("copying any existing content to tmp dir")
-		err = cp(websiteSourceDir, filepath.Join(websiteTmp, "templates"))
+		err = cp(g.websiteSourceDir, filepath.Join(g.websiteTmpDir, "templates"))
 		if err != nil {
 			return err
 		}
@@ -156,13 +162,13 @@ func (g *generator) Generate(ctx context.Context) error {
 	}
 
 	g.infof("rendering missing docs")
-	err = g.renderMissingDocs(providerName, providerSchema)
+	err = g.renderMissingDocs(g.renderedProviderName, providerSchema)
 	if err != nil {
 		return err
 	}
 
 	g.infof("rendering static website")
-	err = g.renderStaticWebsite(providerName, providerSchema)
+	err = g.renderStaticWebsite(g.renderedProviderName, providerSchema)
 	if err != nil {
 		return err
 	}
@@ -181,7 +187,7 @@ func (g *generator) renderMissingResourceDoc(providerName, name, typeName string
 	if err != nil {
 		return fmt.Errorf("unable to render path for resource %q: %w", name, err)
 	}
-	tmplPath = filepath.Join(websiteTmp, websiteSourceDir, tmplPath)
+	tmplPath = filepath.Join(g.websiteTmpDir, g.websiteSourceDir, tmplPath)
 	if fileExists(tmplPath) {
 		g.infof("resource %q template exists, skipping", name)
 		return nil
@@ -192,7 +198,7 @@ func (g *generator) renderMissingResourceDoc(providerName, name, typeName string
 		if err != nil {
 			return fmt.Errorf("unable to render path for resource %q: %w", name, err)
 		}
-		candidatePath = filepath.Join(websiteTmp, websiteSourceDir, candidatePath)
+		candidatePath = filepath.Join(g.websiteTmpDir, g.websiteSourceDir, candidatePath)
 		if fileExists(candidatePath) {
 			g.infof("resource %q static file exists, skipping", name)
 			return nil
@@ -204,7 +210,7 @@ func (g *generator) renderMissingResourceDoc(providerName, name, typeName string
 		return fmt.Errorf("unable to render example file path for %q: %w", name, err)
 	}
 	if examplePath != "" {
-		examplePath = filepath.Join(examplesDir, examplePath)
+		examplePath = filepath.Join(g.examplesDir, examplePath)
 	}
 	if !fileExists(examplePath) {
 		examplePath = ""
@@ -217,7 +223,7 @@ func (g *generator) renderMissingResourceDoc(providerName, name, typeName string
 			return fmt.Errorf("unable to render example import file path for %q: %w", name, err)
 		}
 		if importPath != "" {
-			importPath = filepath.Join(examplesDir, importPath)
+			importPath = filepath.Join(g.examplesDir, importPath)
 		}
 		if !fileExists(importPath) {
 			importPath = ""
@@ -230,7 +236,7 @@ func (g *generator) renderMissingResourceDoc(providerName, name, typeName string
 	if err != nil {
 		return fmt.Errorf("unable to render path for resource %q: %w", name, err)
 	}
-	fallbackTmplPath = filepath.Join(websiteTmp, websiteSourceDir, fallbackTmplPath)
+	fallbackTmplPath = filepath.Join(g.websiteTmpDir, g.websiteSourceDir, fallbackTmplPath)
 	if fileExists(fallbackTmplPath) {
 		g.infof("resource %q fallback template exists", name)
 		tmplData, err := ioutil.ReadFile(fallbackTmplPath)
@@ -259,7 +265,7 @@ func (g *generator) renderMissingProviderDoc(providerName string, schema *tfjson
 	if err != nil {
 		return fmt.Errorf("unable to render path for provider %q: %w", providerName, err)
 	}
-	tmplPath = filepath.Join(websiteTmp, websiteSourceDir, tmplPath)
+	tmplPath = filepath.Join(g.websiteTmpDir, g.websiteSourceDir, tmplPath)
 	if fileExists(tmplPath) {
 		g.infof("provider %q template exists, skipping", providerName)
 		return nil
@@ -270,7 +276,7 @@ func (g *generator) renderMissingProviderDoc(providerName string, schema *tfjson
 		if err != nil {
 			return fmt.Errorf("unable to render path for provider %q: %w", providerName, err)
 		}
-		candidatePath = filepath.Join(websiteTmp, websiteSourceDir, candidatePath)
+		candidatePath = filepath.Join(g.websiteTmpDir, g.websiteSourceDir, candidatePath)
 		if fileExists(candidatePath) {
 			g.infof("provider %q static file exists, skipping", providerName)
 			return nil
@@ -282,7 +288,7 @@ func (g *generator) renderMissingProviderDoc(providerName string, schema *tfjson
 		return fmt.Errorf("unable to render example file path for %q: %w", providerName, err)
 	}
 	if examplePath != "" {
-		examplePath = filepath.Join(examplesDir, examplePath)
+		examplePath = filepath.Join(g.examplesDir, examplePath)
 	}
 	if !fileExists(examplePath) {
 		examplePath = ""
@@ -344,7 +350,7 @@ func (g *generator) renderMissingDocs(providerName string, providerSchema *tfjso
 
 func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfjson.ProviderSchema) error {
 	g.infof("cleaning rendered website dir")
-	err := os.RemoveAll(renderedWebsiteDir)
+	err := os.RemoveAll(g.renderedWebsiteDir)
 	if err != nil {
 		return err
 	}
@@ -353,13 +359,13 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 
 	g.infof("rendering templated website to static markdown")
 
-	err = filepath.Walk(websiteTmp, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(g.websiteTmpDir, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
 			// skip directories
 			return nil
 		}
 
-		rel, err := filepath.Rel(filepath.Join(websiteTmp, websiteSourceDir), path)
+		rel, err := filepath.Rel(filepath.Join(g.websiteTmpDir, g.websiteSourceDir), path)
 		if err != nil {
 			return err
 		}
@@ -372,7 +378,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 			return nil
 		}
 
-		renderedPath := filepath.Join(renderedWebsiteDir, rel)
+		renderedPath := filepath.Join(g.renderedWebsiteDir, rel)
 		err = os.MkdirAll(filepath.Dir(renderedPath), 0755)
 		if err != nil {
 			return err


### PR DESCRIPTION
This updates all the directory and provider configuration that was
previously hardcoded to now be controlled by flags.

Majority of the flags are self explanatory (however I would like some help on 
wordsmithing better descriptions) but one that stands out is the difference 
between `provider-name` and `rendered-provider-name`. Within the code, these 
were previously the same value however I have a use case where the provider is 
registered as "cloudflare" but we want the documentation to capitalise the "C". 
I didn't make it as naive as "just capitalise the provider name" as I know folks 
like GitHub who would hate having "Github" :wink: So, `provider-name` is used 
when looking for the binary and schema and `rendered-provider-name` for when we 
are outputting it to the CLI or documentation. If `rendered-provider-name` is 
empty, then we just assume `provider-name` is fine to output.

Closes #92