### PR TITLE
generate: pass through correct name of schema provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 BUG FIXES:
 
-* cmd/tfplugindocs: Allow single word resources to use templates ([147](https://github.com/hashicorp/terraform-plugin-docs/pull/147)).
+* cmd/tfplugindocs: Allow single word resources to use templates ([#147](https://github.com/hashicorp/terraform-plugin-docs/pull/147)).
+* cmd/tfplugindocs: Pass in correct provider name for data-source and resource schema lookup when overidden with `rendered-provider-name` flag ([#148](https://github.com/hashicorp/terraform-plugin-docs/pull/148)).
 
 # 0.9.0 (June 1, 2022)
 

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -170,13 +170,13 @@ func (g *generator) Generate(ctx context.Context) error {
 	}
 
 	g.infof("rendering missing docs")
-	err = g.renderMissingDocs(g.renderedProviderName, providerSchema)
+	err = g.renderMissingDocs(providerName, providerSchema)
 	if err != nil {
 		return err
 	}
 
 	g.infof("rendering static website")
-	err = g.renderStaticWebsite(g.renderedProviderName, providerSchema)
+	err = g.renderStaticWebsite(providerName, providerSchema)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
After updating to 0.9.0, I found that individual template overrides no
longer worked using the `generate` command however, would work if using
`tfplugindocs` directly. I started looking into why this was and it
boiled down to being that the value from `--rendered-provider-name` was
being incorrectly passed into `resourceSchema` causing the friendly name
(such as `Cloudflare`) to be used instead of the correct schema name
(here, `terraform-provider-cloudflare`) resulting in the schema never
being found for the data-source or resource. This corrects the value we
pass to the render website methods to always be the schema provider, not
the friendly name.

Closes #139