### PR TITLE
expose `RenderedProviderName` to templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ BUG FIXES:
 
 * cmd/tfplugindocs: Allow single word resources to use templates ([147](https://github.com/hashicorp/terraform-plugin-docs/pull/147)).
 
+ENHANCEMENTS:
+
+* cmd/tfplugindocs: Expose `RenderedProviderName` to templates ([#149](https://github.com/hashicorp/terraform-plugin-docs/pull/149)).
+
 # 0.9.0 (June 1, 2022)
 
 NEW FEATURES:

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -255,7 +255,7 @@ func (g *generator) renderMissingResourceDoc(providerName, name, typeName string
 	}
 
 	g.infof("generating template for %q", name)
-	md, err := targetResourceTemplate.Render(name, providerName, typeName, examplePath, importPath, schema)
+	md, err := targetResourceTemplate.Render(name, providerName, g.renderedProviderName, typeName, examplePath, importPath, schema)
 	if err != nil {
 		return fmt.Errorf("unable to render template for %q: %w", name, err)
 	}
@@ -303,7 +303,7 @@ func (g *generator) renderMissingProviderDoc(providerName string, schema *tfjson
 	}
 
 	g.infof("generating template for %q", providerName)
-	md, err := defaultProviderTemplate.Render(providerName, examplePath, schema)
+	md, err := defaultProviderTemplate.Render(providerName, g.renderedProviderName, examplePath, schema)
 	if err != nil {
 		return fmt.Errorf("unable to render template for %q: %w", providerName, err)
 	}
@@ -420,7 +420,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 			}
 
 			tmpl := resourceTemplate(tmplData)
-			render, err := tmpl.Render(resName, providerName, "Data Source", "", "", resSchema)
+			render, err := tmpl.Render(resName, providerName, g.renderedProviderName, "Data Source", "", "", resSchema)
 			if err != nil {
 				return fmt.Errorf("unable to render data source template %q: %w", rel, err)
 			}
@@ -430,13 +430,15 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 			}
 			return nil
 		case "resources/":
+			// spew.Dump(providerSchema.ResourceSchemas, shortName)
 			resSchema, resName := resourceSchema(providerSchema.ResourceSchemas, shortName, relFile)
+			// spew.Dump(resName, resSchema)
 			if resSchema == nil {
 				return fmt.Errorf("unable to find resource for provider (%s) and template (%s)", shortName, relFile)
 			}
 
 			tmpl := resourceTemplate(tmplData)
-			render, err := tmpl.Render(resName, providerName, "Resource", "", "", resSchema)
+			render, err := tmpl.Render(resName, providerName, g.renderedProviderName, "Resource", "", "", resSchema)
 			if err != nil {
 				return fmt.Errorf("unable to render resource template %q: %w", rel, err)
 			}
@@ -448,7 +450,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 		case "": // provider
 			if relFile == "index.md.tmpl" {
 				tmpl := providerTemplate(tmplData)
-				render, err := tmpl.Render(providerName, "", providerSchema.ConfigSchema)
+				render, err := tmpl.Render(providerName, g.renderedProviderName, "", providerSchema.ConfigSchema)
 				if err != nil {
 					return fmt.Errorf("unable to render provider template %q: %w", rel, err)
 				}

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -118,7 +118,7 @@ func (t providerFileTemplate) Render(name string) (string, error) {
 	}{name, providerShortName(name)})
 }
 
-func (t providerTemplate) Render(providerName, exampleFile string, schema *tfjson.Schema) (string, error) {
+func (t providerTemplate) Render(providerName, renderedProviderName, exampleFile string, schema *tfjson.Schema) (string, error) {
 	schemaBuffer := bytes.NewBuffer(nil)
 	err := schemamd.Render(schema, schemaBuffer)
 	if err != nil {
@@ -144,6 +144,8 @@ func (t providerTemplate) Render(providerName, exampleFile string, schema *tfjso
 		ProviderShortName string
 
 		SchemaMarkdown string
+
+		RenderedProviderName string
 	}{
 		Description: schema.Block.Description,
 
@@ -154,10 +156,12 @@ func (t providerTemplate) Render(providerName, exampleFile string, schema *tfjso
 		ProviderShortName: providerShortName(providerName),
 
 		SchemaMarkdown: schemaComment + "\n" + schemaBuffer.String(),
+
+		RenderedProviderName: renderedProviderName,
 	})
 }
 
-func (t resourceTemplate) Render(name, providerName, typeName, exampleFile, importFile string, schema *tfjson.Schema) (string, error) {
+func (t resourceTemplate) Render(name, providerName, renderedProviderName, typeName, exampleFile, importFile string, schema *tfjson.Schema) (string, error) {
 	schemaBuffer := bytes.NewBuffer(nil)
 	err := schemamd.Render(schema, schemaBuffer)
 	if err != nil {
@@ -184,6 +188,8 @@ func (t resourceTemplate) Render(name, providerName, typeName, exampleFile, impo
 		ProviderShortName string
 
 		SchemaMarkdown string
+
+		RenderedProviderName string
 	}{
 		Type:        typeName,
 		Name:        name,
@@ -199,6 +205,8 @@ func (t resourceTemplate) Render(name, providerName, typeName, exampleFile, impo
 		ProviderShortName: providerShortName(providerName),
 
 		SchemaMarkdown: schemaComment + "\n" + schemaBuffer.String(),
+
+		RenderedProviderName: renderedProviderName,
 	})
 }
 


### PR DESCRIPTION
Updates the templating variables to include `RenderedProviderName` which is the
value from `--rendered-provider-name` when invoking `generate`.

Allows doing the following in templates resulting in a nicer docs experience.

```
page_title: "{{.Name}} {{.Type}} - {{.RenderedProviderName}}"
```

Output:


```
# old
page_title: "Example Resource - terraform-provider-cloudflare"

# proposed
page_title: "Example Resource - Cloudflare"
```
