### PR TITLE
Do not error if data source or resource not found in schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.10.1 (June 14, 2022)
+
+BUG FIXES:
+
+* cmd/tfplugindocs: Do not error when schema not found, issue log warning ([#151](https://github.com/hashicorp/terraform-plugin-docs/pull/151)).
+
 # 0.10.0 (June 13, 2022)
 
 BUG FIXES:

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -427,7 +427,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 				}
 				return nil
 			}
-			g.infof("data source entitled %q, or %q does not exist", shortName, resName)
+			g.warnf("data source entitled %q, or %q does not exist", shortName, resName)
 		case "resources/":
 			resSchema, resName := resourceSchema(providerSchema.ResourceSchemas, shortName, relFile)
 			if resSchema != nil {

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -442,7 +442,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 				}
 				return nil
 			}
-			g.infof("resource entitled %q, or %q does not exist", shortName, resName)
+			g.warnf("resource entitled %q, or %q does not exist", shortName, resName)
 		case "": // provider
 			if relFile == "index.md.tmpl" {
 				tmpl := providerTemplate(tmplData)

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -415,38 +415,32 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 		switch relDir {
 		case "data-sources/":
 			resSchema, resName := resourceSchema(providerSchema.DataSourceSchemas, shortName, relFile)
-			if resSchema == nil {
-				return fmt.Errorf("unable to find resource for provider (%s) and template (%s)", shortName, relFile)
+			if resSchema != nil {
+				tmpl := resourceTemplate(tmplData)
+				render, err := tmpl.Render(resName, providerName, g.renderedProviderName, "Data Source", "", "", resSchema)
+				if err != nil {
+					return fmt.Errorf("unable to render data source template %q: %w", rel, err)
+				}
+				_, err = out.WriteString(render)
+				if err != nil {
+					return fmt.Errorf("unable to write rendered string: %w", err)
+				}
+				return nil
 			}
-
-			tmpl := resourceTemplate(tmplData)
-			render, err := tmpl.Render(resName, providerName, g.renderedProviderName, "Data Source", "", "", resSchema)
-			if err != nil {
-				return fmt.Errorf("unable to render data source template %q: %w", rel, err)
-			}
-			_, err = out.WriteString(render)
-			if err != nil {
-				return fmt.Errorf("unable to write rendered string: %w", err)
-			}
-			return nil
 		case "resources/":
-			// spew.Dump(providerSchema.ResourceSchemas, shortName)
 			resSchema, resName := resourceSchema(providerSchema.ResourceSchemas, shortName, relFile)
-			// spew.Dump(resName, resSchema)
-			if resSchema == nil {
-				return fmt.Errorf("unable to find resource for provider (%s) and template (%s)", shortName, relFile)
+			if resSchema != nil {
+				tmpl := resourceTemplate(tmplData)
+				render, err := tmpl.Render(resName, providerName, g.renderedProviderName, "Resource", "", "", resSchema)
+				if err != nil {
+					return fmt.Errorf("unable to render resource template %q: %w", rel, err)
+				}
+				_, err = out.WriteString(render)
+				if err != nil {
+					return fmt.Errorf("unable to write regindered string: %w", err)
+				}
+				return nil
 			}
-
-			tmpl := resourceTemplate(tmplData)
-			render, err := tmpl.Render(resName, providerName, g.renderedProviderName, "Resource", "", "", resSchema)
-			if err != nil {
-				return fmt.Errorf("unable to render resource template %q: %w", rel, err)
-			}
-			_, err = out.WriteString(render)
-			if err != nil {
-				return fmt.Errorf("unable to write regindered string: %w", err)
-			}
-			return nil
 		case "": // provider
 			if relFile == "index.md.tmpl" {
 				tmpl := providerTemplate(tmplData)

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -427,6 +427,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 				}
 				return nil
 			}
+			g.infof("data source entitled %q, or %q does not exist", shortName, resName)
 		case "resources/":
 			resSchema, resName := resourceSchema(providerSchema.ResourceSchemas, shortName, relFile)
 			if resSchema != nil {
@@ -441,6 +442,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 				}
 				return nil
 			}
+			g.infof("resource entitled %q, or %q does not exist", shortName, resName)
 		case "": // provider
 			if relFile == "index.md.tmpl" {
 				tmpl := providerTemplate(tmplData)

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -68,7 +68,7 @@ func resourceSchema(schemas map[string]*tfjson.Schema, providerShortName, templa
 		return schema, resName
 	}
 
-	return nil, ""
+	return nil, resName
 }
 
 func writeFile(path string, data string) error {

--- a/internal/provider/util_test.go
+++ b/internal/provider/util_test.go
@@ -31,7 +31,7 @@ func Test_resourceSchema(t *testing.T) {
 			providerShortName:    "tls",
 			templateFileName:     "http.md.tmpl",
 			expectedSchema:       nil,
-			expectedResourceName: "",
+			expectedResourceName: "tls_http",
 		},
 		"provider short name concatenated with template file name matches schema name": {
 			schemas: map[string]*tfjson.Schema{
@@ -49,7 +49,7 @@ func Test_resourceSchema(t *testing.T) {
 			providerShortName:    "tls",
 			templateFileName:     "not_found.md.tmpl",
 			expectedSchema:       nil,
-			expectedResourceName: "",
+			expectedResourceName: "tls_not_found",
 		},
 		"provider short name concatenated with same template file name matches schema name": {
 			schemas: map[string]*tfjson.Schema{


### PR DESCRIPTION
The changes present in `v0.10.0` result in an error being generated if `providerShortName` or `providerShortName` concatenated with the template filename (following stripping of file extensions) are not found in the _data source_ or _resource_ schemas.

This PR reinstates the behaviour present in `v0.9.0`, where the failure to find the schema does not result in an error.