### PR TITLE
Prepare for `v0.11.0` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.10.2 (Unreleased)
+# 0.11.0 (June 28, 2022)
 
 NEW FEATURES:
 
@@ -7,6 +7,7 @@ NEW FEATURES:
 BUG FIXES:
 
 * cmd/tfplugindocs: Pass through filepaths for `examples` and `import` to allow use of `HasExample` and `HasImport` template helpers in custom templates ([#155](https://github.com/hashicorp/terraform-plugin-docs/pull/155)).
+* cmd/tfplugindocs: Fixed issue with the generation of title and reference links, when nested attributes go too deep ([#56](https://github.com/hashicorp/terraform-plugin-docs/pull/56)).
 
 # 0.10.1 (June 14, 2022)
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ When you run `tfplugindocs` from root directory of the provider the tool takes t
 For inspiration, you can look at the templates and output of the
 [`terraform-provider-random`](https://github.com/hashicorp/terraform-provider-random)
 and [`terraform-provider-tls`](https://github.com/hashicorp/terraform-provider-tls).
-And you can browser their respective docs on the Terraform Registry,
+You can browse their respective docs on the Terraform Registry,
 [here](https://registry.terraform.io/providers/hashicorp/random/latest/docs)
 and [here](https://registry.terraform.io/providers/hashicorp/tls/latest/docs).
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,62 @@
 # terraform-plugin-docs
 
-This repository contains tools and packages for creating Terraform plugin docs (currently only provider plugins). The primary way users will interact with this is the **tfplugindocs** CLI tool to generate and validate plugin documentation.
+This repository contains tools and packages for creating Terraform plugin docs (currently only provider plugins).
+The primary way users will interact with this is the `tfplugindocs` CLI tool to generate and validate plugin documentation.
 
-## tfplugindocs
+## `tfplugindocs`
 
-The **tfplugindocs** CLI has two main commands, `validate` and `generate` (`generate` is the default). This tool will let you generate documentation for your provider from live example .tf files and markdown templates. It will also export schema information from the provider (using `terraform providers schema -json`), and sync the schema with the reference documents. If your documentation only consists of simple examples and schema information, the tool can also generate missing template files to make website creation extremely simple for most providers.
+The `tfplugindocs` CLI has two main commands, `validate` and `generate` (`generate` is the default).
+This tool will let you generate documentation for your provider from live example `.tf` files and markdown templates.
+It will also export schema information from the provider (using `terraform providers schema -json`),
+and sync the schema with the reference documents.
+
+If your documentation only consists of simple examples and schema information,
+the tool can also generate missing template files to make website creation extremely simple for most providers.
+
+### Installation
+
+You can install a copy of the binary manually from the [releases](https://github.com/hashicorp/terraform-plugin-docs/releases),
+or you can optionally use the [tools.go model](https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md)
+for tool installation.
+
+### Usage
+
+```shell
+$ tfplugindocs --help
+Usage: tfplugindocs [--version] [--help] <command> [<args>]
+
+Available commands are:
+                the generate command is run by default
+    generate    generates a plugin website from code, templates, and examples for the current directory
+    validate    validates a plugin website for the current directory
+       
+```
+
+`generate` command:
+
+```shell
+$ tfplugindocs generate --help
+
+Usage: tfplugindocs generate [<args>]
+
+    --examples-dir <ARG>             examples directory                                                        (default: "examples")
+    --ignore-deprecated <ARG>        don't generate documentation for deprecated resources and data-sources    (default: "false")
+    --legacy-sidebar <ARG>           generate the legacy .erb sidebar file                                     (default: "false")
+    --provider-name <ARG>            provider name, as used in Terraform configurations
+    --rendered-provider-name <ARG>   provider name, as generated in documentation (ex. page titles, ...)
+    --rendered-website-dir <ARG>     output directory                                                          (default: "docs")
+    --tf-version <ARG>               terraform binary version to download
+    --website-source-dir <ARG>       templates directory                                                       (default: "templates")
+    --website-temp-dir <ARG>         temporary directory (used during generation)
+```
+
+`validate` command:
+
+```shell
+$ tfplugindocs validate --help
+
+Usage: tfplugindocs validate [<args>]
+```
 
 ### How it Works
 
@@ -19,7 +71,12 @@ When you run `tfplugindocs` from root directory of the provider the tool takes t
 * Copy all non-template files to the output website directory
 * Process all the remaining templates to generate files for the output website directory
 
-You can see an example of the templates and output in [paultyng/terraform-provider-unifi](https://github.com/paultyng/terraform-provider-unifi) and browse the generated docs in the [Terraform Registry](https://registry.terraform.io/providers/paultyng/unifi/latest/docs).
+For inspiration, you can look at the templates and output of the
+[`terraform-provider-random`](https://github.com/hashicorp/terraform-provider-random)
+and [`terraform-provider-tls`](https://github.com/hashicorp/terraform-provider-tls).
+And you can browser their respective docs on the Terraform Registry,
+[here](https://registry.terraform.io/providers/hashicorp/random/latest/docs)
+and [here](https://registry.terraform.io/providers/hashicorp/tls/latest/docs).
 
 #### About the `id` attribute
 
@@ -87,10 +144,11 @@ TBD
 | `plainmarkdown` | Render Markdown content as plaintext                                                                               |
 | `split`         | Split string into sub-strings, eg. `split .Name "_"`                                                               |
 
-### Installation
-
-You can install a copy of the binary manually from the releases, or you can optionally use the [tools.go model](https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md) for tool installation.
 
 ## Disclaimer
 
-This experimental repository contains software which is still being developed and in the alpha testing stage. It is not ready for production use.
+This is still under development: while it's being used for production-ready providers, you might still find bugs
+and limitations. In those cases, please report [issues](https://github.com/hashicorp/terraform-plugin-docs/issues)
+or, if you can, submit a [pull-request](https://github.com/hashicorp/terraform-plugin-docs/pulls).
+
+Your help and patience is truly appreciated.

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
+	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,8 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
@@ -196,6 +198,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
+golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
* Refreshing dependencies
* Updated CHANGELOG
* Updated README to explicitly report the output of the `--help` command ("Usage" section), as a quick and dirty way to document the flags supported by the commands