### PR TITLE
fix(template functions): Use function Title instead of ToTitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.12.1 (July 04, 2022)
+
+BUG FIXES:
+
+* template functions: funtion `title` creates capitalize strings instead of upper strings ([#165](https://github.com/hashicorp/terraform-plugin-docs/pull/165)).
+
 # 0.12.0 (June 29, 2022)
 
 BUG FIXES:
@@ -71,13 +77,13 @@ BUG FIXES:
 
 ENHANCEMENTS:
 
-* cmd/tfplugindocs: Use existing Terraform CLI binary if available on PATH, otherwise download latest Terraform CLI binary (https://github.com/hashicorp/terraform-plugin-docs/pull/124).
-* cmd/tfplugindocs: Added `tf-version` flag for specifying Terraform CLI binary version to download, superseding the PATH lookup (https://github.com/hashicorp/terraform-plugin-docs/pull/124).
+* cmd/tfplugindocs: Use existing Terraform CLI binary if available on PATH, otherwise download latest Terraform CLI binary (<https://github.com/hashicorp/terraform-plugin-docs/pull/124>).
+* cmd/tfplugindocs: Added `tf-version` flag for specifying Terraform CLI binary version to download, superseding the PATH lookup (<https://github.com/hashicorp/terraform-plugin-docs/pull/124>).
 
 BUG FIXES:
 
-* cmd/tfplugindocs: Swapped `.Type` and `.Name` resource and data source template fields so they correctly align (https://github.com/hashicorp/terraform-plugin-docs/pull/44).
-* schemamd: Switched attribute name rendering from bold text to code blocks so the Terraform Registry treats them as anchor links (https://github.com/hashicorp/terraform-plugin-docs/pull/59).
+* cmd/tfplugindocs: Swapped `.Type` and `.Name` resource and data source template fields so they correctly align (<https://github.com/hashicorp/terraform-plugin-docs/pull/44>).
+* schemamd: Switched attribute name rendering from bold text to code blocks so the Terraform Registry treats them as anchor links (<https://github.com/hashicorp/terraform-plugin-docs/pull/59>).
 
 # 0.6.0 (March 14, 2022)
 

--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ using the following data fields and functions:
 | `plainmarkdown` | Render Markdown content as plaintext.                                                             |
 | `prefixlines`   | Add a prefix to all (newline-separated) lines in a string.                                        |
 | `split`         | Split string into sub-strings, by a given separator (ex. `split .Name "_"`).                      |
-| `title`         | Equivalent to [`strings.ToLower`](https://pkg.go.dev/strings#ToTitle).                            |
+| `title`         | Equivalent to [`cases.Title`](https://pkg.go.dev/golang.org/x/text/cases#Title).                  |
 | `tffile`        | A special case of the `codefile` function, designed for Terraform files (i.e. `.tf`).             |
 | `trimspace`     | Equivalent to [`strings.TrimSpace`](https://pkg.go.dev/strings#TrimSpace).                        |
-| `upper`         | Equivalent to [`strings.ToLower`](https://pkg.go.dev/strings#ToUpper).                            |
+| `upper`         | Equivalent to [`strings.ToUpper`](https://pkg.go.dev/strings#ToUpper).                            |
 
 ## Disclaimer
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mitchellh/cli v1.1.4
 	github.com/russross/blackfriday v1.6.0
 	github.com/zclconf/go-cty v1.10.0
+	golang.org/x/text v0.3.7
 )
 
 require (
@@ -37,5 +38,4 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
-	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,6 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
-golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -196,8 +194,6 @@ golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"text/template"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	tfjson "github.com/hashicorp/terraform-json"
 
 	"github.com/hashicorp/terraform-plugin-docs/internal/mdplain"
@@ -31,6 +34,7 @@ type (
 
 func newTemplate(name, text string) (*template.Template, error) {
 	tmpl := template.New(name)
+	titleCaser := cases.Title(language.Und)
 
 	tmpl.Funcs(map[string]interface{}{
 		"codefile":      tmplfuncs.CodeFile,
@@ -39,7 +43,7 @@ func newTemplate(name, text string) (*template.Template, error) {
 		"prefixlines":   tmplfuncs.PrefixLines,
 		"split":         strings.Split,
 		"tffile":        terraformCodeFile,
-		"title":         strings.ToTitle,
+		"title":         titleCaser.String,
 		"trimspace":     strings.TrimSpace,
 		"upper":         strings.ToUpper,
 	})

--- a/internal/provider/template_test.go
+++ b/internal/provider/template_test.go
@@ -1,0 +1,47 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRenderStringTemplate(t *testing.T) {
+	template := `
+Plainmarkdown: {{ plainmarkdown .Text }}
+Split: {{ $arr := split .Text " "}}{{ index $arr 3 }}
+Trimspace: {{ trimspace .Text }}
+Lower: {{ upper .Text }}
+Upper: {{ lower .Text }}
+Title: {{ title .Text }}
+Prefixlines:
+{{ prefixlines "  " .MultiLineTest }}
+`
+
+	expectedString := `
+Plainmarkdown: my Odly cAsed striNg
+Split: striNg
+Trimspace: my Odly cAsed striNg
+Lower: MY ODLY CASED STRING
+Upper: my odly cased string
+Title: My Odly Cased String
+Prefixlines:
+  This text used
+  multiple lines
+`
+	result, err := renderStringTemplate("testTemplate", template, struct {
+		Text          string
+		MultiLineTest string
+	}{
+		Text: "my Odly cAsed striNg",
+		MultiLineTest: `This text used
+multiple lines`,
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(expectedString, result) {
+		t.Errorf("expected: %+v, got: %+v", expectedString, result)
+	}
+}


### PR DESCRIPTION
Use function Title instead of ToTitle to get capitalize strings instead of upper strings

Using `cases.Title` because the `strings.Title` function is deprecated and refs to `cases.Title`

resolves #164 

