### PR TITLE
feat: improve error experience, linting, and more

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+run:
+  tests: False
+  timeout: 3m
+
+severity:
+  default-severity: error
+  rules:
+    - linters:
+        - errcheck
+        - gocritic
+      severity: warning
+
+linters:
+  enable:
+    - asciicheck
+    - exportloopref
+    - gci
+    - gofmt
+    - misspell

--- a/cmd/tfplugindocs/main.go
+++ b/cmd/tfplugindocs/main.go
@@ -3,9 +3,8 @@ package main
 import (
 	"os"
 
-	"github.com/mattn/go-colorable"
-
 	"github.com/hashicorp/terraform-plugin-docs/internal/cmd"
+	"github.com/mattn/go-colorable"
 )
 
 func main() {

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -42,7 +42,7 @@ func (cmd *generateCmd) Help() string {
 		}
 	})
 
-	strBuilder.WriteString(fmt.Sprintf("\nUsage: tfplugindocs generate [<args>]\n\n"))
+	strBuilder.WriteString("\nUsage: tfplugindocs generate [<args>]\n\n")
 	cmd.Flags().VisitAll(func(f *flag.Flag) {
 		if f.DefValue != "" {
 			strBuilder.WriteString(fmt.Sprintf("    --%s <ARG> %s%s%s  (default: %q)\n",

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -23,7 +23,6 @@ func (cmd *commonCmd) run(r func() error) int {
 }
 
 func initCommands(ui cli.Ui) map[string]cli.CommandFactory {
-
 	generateFactory := func() (cli.Command, error) {
 		return &generateCmd{
 			commonCmd: commonCmd{

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -54,7 +54,7 @@ func initCommands(ui cli.Ui) map[string]cli.CommandFactory {
 		"":         defaultFactory,
 		"generate": generateFactory,
 		"validate": validateFactory,
-		//"serve": serveFactory,
+		// "serve": serveFactory,
 	}
 }
 
@@ -81,7 +81,7 @@ func Run(name, version string, args []string, stdin io.Reader, stdout, stderr io
 
 	commands := initCommands(ui)
 
-	cli := cli.CLI{
+	cmd := cli.CLI{
 		Name:       name,
 		Args:       args,
 		Commands:   commands,
@@ -90,7 +90,7 @@ func Run(name, version string, args []string, stdin io.Reader, stdout, stderr io
 		Version:    version,
 	}
 
-	exitCode, err := cli.Run()
+	exitCode, err := cmd.Run()
 	if err != nil {
 		return 1
 	}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -30,7 +30,7 @@ func (cmd *validateCmd) Help() string {
 		}
 	})
 
-	strBuilder.WriteString(fmt.Sprintf("\nUsage: tfplugindocs validate [<args>]\n\n"))
+	strBuilder.WriteString("\nUsage: tfplugindocs validate [<args>]\n\n")
 	cmd.Flags().VisitAll(func(f *flag.Flag) {
 		if f.DefValue != "" {
 			strBuilder.WriteString(fmt.Sprintf("    --%s <ARG> %s%s%s  (default: %q)\n",

--- a/internal/mdplain/renderer.go
+++ b/internal/mdplain/renderer.go
@@ -18,7 +18,7 @@ func (options *Text) GetFlags() int {
 
 func (options *Text) TitleBlock(out *bytes.Buffer, text []byte) {
 	text = bytes.TrimPrefix(text, []byte("% "))
-	text = bytes.Replace(text, []byte("\n% "), []byte("\n"), -1)
+	text = bytes.ReplaceAll(text, []byte("\n% "), []byte("\n"))
 	out.Write(text)
 	out.WriteString("\n")
 }
@@ -29,7 +29,6 @@ func (options *Text) Header(out *bytes.Buffer, text func() bool, level int, id s
 
 	if !text() {
 		out.Truncate(marker)
-		return
 	}
 }
 
@@ -57,7 +56,7 @@ func (options *Text) BlockQuote(out *bytes.Buffer, text []byte) {
 	out.Write(text)
 }
 
-func (options *Text) Table(out *bytes.Buffer, header []byte, body []byte, columnData []int) {
+func (options *Text) Table(out *bytes.Buffer, header, body []byte, columnData []int) {
 	doubleSpace(out)
 	out.Write(header)
 	out.Write(body)
@@ -93,7 +92,6 @@ func (options *Text) List(out *bytes.Buffer, text func() bool, flags int) {
 
 	if !text() {
 		out.Truncate(marker)
-		return
 	}
 }
 
@@ -107,7 +105,6 @@ func (options *Text) Paragraph(out *bytes.Buffer, text func() bool) {
 
 	if !text() {
 		out.Truncate(marker)
-		return
 	}
 }
 
@@ -130,26 +127,19 @@ func (options *Text) Emphasis(out *bytes.Buffer, text []byte) {
 	out.Write(text)
 }
 
-func (options *Text) Image(out *bytes.Buffer, link []byte, title []byte, alt []byte) {
-	return
-}
+func (options *Text) Image(out *bytes.Buffer, link, title, alt []byte) {}
 
-func (options *Text) LineBreak(out *bytes.Buffer) {
-	return
-}
+func (options *Text) LineBreak(out *bytes.Buffer) {}
 
-func (options *Text) Link(out *bytes.Buffer, link []byte, title []byte, content []byte) {
+func (options *Text) Link(out *bytes.Buffer, link, title, content []byte) {
 	out.Write(content)
 	if !isRelativeLink(link) {
 		out.WriteString(" ")
 		out.Write(link)
 	}
-	return
 }
 
-func (options *Text) RawHtmlTag(out *bytes.Buffer, text []byte) {
-	return
-}
+func (options *Text) RawHtmlTag(out *bytes.Buffer, text []byte) {}
 
 func (options *Text) TripleEmphasis(out *bytes.Buffer, text []byte) {
 	out.Write(text)
@@ -159,9 +149,7 @@ func (options *Text) StrikeThrough(out *bytes.Buffer, text []byte) {
 	out.Write(text)
 }
 
-func (options *Text) FootnoteRef(out *bytes.Buffer, ref []byte, id int) {
-	return
-}
+func (options *Text) FootnoteRef(out *bytes.Buffer, ref []byte, id int) {}
 
 func (options *Text) Entity(out *bytes.Buffer, entity []byte) {
 	out.Write(entity)
@@ -171,25 +159,15 @@ func (options *Text) NormalText(out *bytes.Buffer, text []byte) {
 	out.Write(text)
 }
 
-func (options *Text) Smartypants(out *bytes.Buffer, text []byte) {
-	return
-}
+func (options *Text) Smartypants(out *bytes.Buffer, text []byte) {}
 
-func (options *Text) DocumentHeader(out *bytes.Buffer) {
-	return
-}
+func (options *Text) DocumentHeader(out *bytes.Buffer) {}
 
-func (options *Text) DocumentFooter(out *bytes.Buffer) {
-	return
-}
+func (options *Text) DocumentFooter(out *bytes.Buffer) {}
 
-func (options *Text) TocHeader(text []byte, level int) {
-	return
-}
+func (options *Text) TocHeader(text []byte, level int) {}
 
-func (options *Text) TocFinalize() {
-	return
-}
+func (options *Text) TocFinalize() {}
 
 func doubleSpace(out *bytes.Buffer) {
 	if out.Len() > 0 {
@@ -214,5 +192,5 @@ func isRelativeLink(link []byte) (yes bool) {
 	if len(link) == 1 && link[0] == '/' {
 		yes = true
 	}
-	return
+	return yes
 }

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -569,6 +569,10 @@ provider %[1]q {
 		return nil, fmt.Errorf("unable to create Terraform CLI: %w", err)
 	}
 
+	// Pass stderr through to the end user, as if there is an error, the output from
+	// terraform will help troubleshoot.
+	tf.SetStderr(os.Stderr)
+
 	g.infof("running terraform init")
 	err = tf.Init(ctx, tfexec.Get(false), tfexec.PluginDir("./plugins"))
 	if err != nil {

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -112,7 +112,7 @@ func (g *generator) Generate(ctx context.Context) error {
 
 	wd, err := os.Getwd()
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to get working directory: %w", err)
 	}
 
 	providerName := g.providerName
@@ -130,20 +130,18 @@ func (g *generator) Generate(ctx context.Context) error {
 	case g.websiteTmpDir == "":
 		g.websiteTmpDir, err = ioutil.TempDir("", "tfws")
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to create temporary directory: %w", err)
 		}
 		defer os.RemoveAll(g.websiteTmpDir)
 	default:
 		g.infof("cleaning tmp dir %q", g.websiteTmpDir)
-		err = os.RemoveAll(g.websiteTmpDir)
-		if err != nil {
-			return err
+		if err = os.RemoveAll(g.websiteTmpDir); err != nil {
+			return fmt.Errorf("unable to clean temporary directory: %w", err)
 		}
 
 		g.infof("creating tmp dir %q", g.websiteTmpDir)
-		err = os.MkdirAll(g.websiteTmpDir, 0755)
-		if err != nil {
-			return err
+		if err = os.MkdirAll(g.websiteTmpDir, 0o755); err != nil {
+			return fmt.Errorf("unable to create temporary directory: %w", err)
 		}
 	}
 
@@ -161,26 +159,26 @@ func (g *generator) Generate(ctx context.Context) error {
 		g.infof("copying any existing content to tmp dir")
 		err = cp(g.websiteSourceDir, filepath.Join(g.websiteTmpDir, "templates"))
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to copy content to temporary directory: %w", err)
 		}
 	}
 
 	g.infof("exporting schema from Terraform")
 	providerSchema, err := g.terraformProviderSchema(ctx, providerName)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to export schema: %w", err)
 	}
 
 	g.infof("rendering missing docs")
 	err = g.renderMissingDocs(providerName, providerSchema)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to render missing docs: %w", err)
 	}
 
 	g.infof("rendering static website")
 	err = g.renderStaticWebsite(providerName, providerSchema)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to render static website: %w", err)
 	}
 
 	// TODO: may not ever need this, unsure on when this will go live
@@ -370,7 +368,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 	g.infof("cleaning rendered website dir")
 	err := os.RemoveAll(g.renderedWebsiteDir)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to clean rendered website dir: %w", err)
 	}
 
 	shortName := providerShortName(providerName)
@@ -385,7 +383,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 
 		rel, err := filepath.Rel(filepath.Join(g.websiteTmpDir, g.websiteSourceDir), path)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to get relative path for %q: %w", path, err)
 		}
 
 		relDir, relFile := filepath.Split(rel)
@@ -397,15 +395,18 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 		}
 
 		renderedPath := filepath.Join(g.renderedWebsiteDir, rel)
-		err = os.MkdirAll(filepath.Dir(renderedPath), 0755)
+		err = os.MkdirAll(filepath.Dir(renderedPath), 0o755)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to create dir %q: %w", filepath.Dir(renderedPath), err)
 		}
 
 		ext := filepath.Ext(path)
 		if ext != ".tmpl" {
 			g.infof("copying non-template file: %q", rel)
-			return cp(path, renderedPath)
+			if err = cp(path, renderedPath); err != nil {
+				return fmt.Errorf("unable to copy %q to %q: %w", path, renderedPath, err)
+			}
+			return nil
 		}
 
 		renderedPath = strings.TrimSuffix(renderedPath, ext)
@@ -417,7 +418,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 
 		out, err := os.Create(renderedPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to create file %q: %w", renderedPath, err)
 		}
 		defer out.Close()
 
@@ -481,7 +482,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 		return nil
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to render website: %w", err)
 	}
 
 	return nil
@@ -494,7 +495,7 @@ func (g *generator) terraformProviderSchema(ctx context.Context, providerName st
 
 	tmpDir, err := ioutil.TempDir("", "tfws")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to create temp dir: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
@@ -514,7 +515,7 @@ func (g *generator) terraformProviderSchema(ctx context.Context, providerName st
 	// TODO: constrain env here to make it a little safer?
 	_, err = runCmd(buildCmd)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to build provider %q: %w", shortName, err)
 	}
 
 	err = writeFile(filepath.Join(tmpDir, "provider.tf"), fmt.Sprintf(`
@@ -522,7 +523,7 @@ provider %[1]q {
 }
 `, shortName))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to write provider.tf: %w", err)
 	}
 
 	i := install.NewInstaller()
@@ -551,24 +552,24 @@ provider %[1]q {
 
 	tfBin, err := i.Ensure(context.Background(), sources)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to ensure Terraform CLI binary: %w", err)
 	}
 
 	tf, err := tfexec.NewTerraform(tmpDir, tfBin)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to create Terraform CLI: %w", err)
 	}
 
 	g.infof("running terraform init")
 	err = tf.Init(ctx, tfexec.Get(false), tfexec.PluginDir("./plugins"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to init Terraform: %w", err)
 	}
 
 	g.infof("getting provider schema")
 	schemas, err := tf.ProvidersSchema(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get provider schema: %w", err)
 	}
 
 	if ps, ok := schemas.Schemas[shortName]; ok {

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -65,7 +65,7 @@ func terraformCodeFile(file string) (string, error) {
 func renderTemplate(name string, text string, out io.Writer, data interface{}) error {
 	tmpl, err := newTemplate(name, text)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to parse template %q: %w", text, err)
 	}
 
 	err = tmpl.Execute(out, data)
@@ -81,7 +81,7 @@ func renderStringTemplate(name, text string, data interface{}) (string, error) {
 
 	err := renderTemplate(name, text, &buf, data)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("unable to render template: %w", err)
 	}
 
 	return buf.String(), nil

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -7,14 +7,12 @@ import (
 	"strings"
 	"text/template"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
 	tfjson "github.com/hashicorp/terraform-json"
-
 	"github.com/hashicorp/terraform-plugin-docs/internal/mdplain"
 	"github.com/hashicorp/terraform-plugin-docs/internal/tmplfuncs"
 	"github.com/hashicorp/terraform-plugin-docs/schemamd"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -62,7 +60,7 @@ func terraformCodeFile(file string) (string, error) {
 	return tmplfuncs.CodeFile("terraform", file)
 }
 
-func renderTemplate(name string, text string, out io.Writer, data interface{}) error {
+func renderTemplate(name, text string, out io.Writer, data interface{}) error {
 	tmpl, err := newTemplate(name, text)
 	if err != nil {
 		return fmt.Errorf("unable to parse template %q: %w", text, err)

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -71,14 +70,14 @@ func resourceSchema(schemas map[string]*tfjson.Schema, providerShortName, templa
 	return nil, resName
 }
 
-func writeFile(path string, data string) error {
+func writeFile(path, data string) error {
 	dir, _ := filepath.Split(path)
 	err := os.MkdirAll(dir, 0o755)
 	if err != nil {
 		return fmt.Errorf("unable to make dir %q: %w", dir, err)
 	}
 
-	err = ioutil.WriteFile(path, []byte(data), 0o644)
+	err = os.WriteFile(path, []byte(data), 0o644)
 	if err != nil {
 		return fmt.Errorf("unable to write file %q: %w", path, err)
 	}
@@ -90,7 +89,7 @@ func runCmd(cmd *exec.Cmd) ([]byte, error) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Printf("error executing %q, %v", cmd.Path, cmd.Args)
-		log.Printf(string(output))
+		log.Println(string(output))
 		return nil, fmt.Errorf("error executing %q: %w", cmd.Path, err)
 	}
 	return output, nil

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -73,12 +73,12 @@ func resourceSchema(schemas map[string]*tfjson.Schema, providerShortName, templa
 
 func writeFile(path string, data string) error {
 	dir, _ := filepath.Split(path)
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0o755)
 	if err != nil {
 		return fmt.Errorf("unable to make dir %q: %w", dir, err)
 	}
 
-	err = ioutil.WriteFile(path, []byte(data), 0644)
+	err = ioutil.WriteFile(path, []byte(data), 0o644)
 	if err != nil {
 		return fmt.Errorf("unable to write file %q: %w", path, err)
 	}
@@ -99,12 +99,12 @@ func runCmd(cmd *exec.Cmd) ([]byte, error) {
 func cp(srcDir, dstDir string) error {
 	err := filepath.Walk(srcDir, func(srcPath string, f os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to walk %q: %w", srcPath, err)
 		}
 
 		relPath, err := filepath.Rel(srcDir, srcPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to get relative path for %q: %w", srcPath, err)
 		}
 
 		dstPath := filepath.Join(dstDir, relPath)
@@ -112,11 +112,11 @@ func cp(srcDir, dstDir string) error {
 		switch mode := f.Mode(); {
 		case mode.IsDir():
 			if err := os.Mkdir(dstPath, f.Mode()); err != nil && !os.IsExist(err) {
-				return err
+				return fmt.Errorf("unable to create dir %q: %w", dstPath, err)
 			}
 		case mode.IsRegular():
 			if err := copyFile(srcPath, dstPath, mode); err != nil {
-				return err
+				return fmt.Errorf("unable to copy file %q to %q: %w", srcPath, dstPath, err)
 			}
 		default:
 			return fmt.Errorf("unknown file type (%d / %s) for %s", f.Mode(), f.Mode().String(), srcPath)

--- a/internal/provider/validate.go
+++ b/internal/provider/validate.go
@@ -25,13 +25,13 @@ func Validate(ui cli.Ui) error {
 		ui.Info("detected templates directory, running checks...")
 		err := validateTemplates(ui, "templates")
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid templates directory: %w", err)
 		}
 		if dirExists("examples") {
 			ui.Info("detected examples directory for templates, running checks...")
 			err = validateExamples(ui, "examples")
 			if err != nil {
-				return err
+				return fmt.Errorf("invalid examples directory: %w", err)
 			}
 		}
 		return err
@@ -73,7 +73,7 @@ func validateTemplates(ui cli.Ui, dir string) error {
 	for _, c := range checks {
 		checkIssues, err := c(dir)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid templates directory: %w", err)
 		}
 		issues = append(issues, checkIssues...)
 	}
@@ -109,7 +109,7 @@ func validateStaticDocs(ui cli.Ui, dir string) error {
 	for _, c := range checks {
 		checkIssues, err := c(dir)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid static docs directory: %w", err)
 		}
 		issues = append(issues, checkIssues...)
 	}
@@ -138,7 +138,7 @@ func checkBlockedExtensions(exts ...string) check {
 		issues := []issue{}
 		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return err
+				return fmt.Errorf("error checking for blocked extensions: %w", err)
 			}
 			if info.IsDir() {
 				return nil
@@ -156,7 +156,7 @@ func checkBlockedExtensions(exts ...string) check {
 			return nil
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error checking for blocked extensions: %w", err)
 		}
 		return issues, nil
 	}
@@ -167,7 +167,7 @@ func checkAllowedExtensions(exts ...string) check {
 		issues := []issue{}
 		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return err
+				return fmt.Errorf("error checking for allowed extensions: %w", err)
 			}
 			if info.IsDir() {
 				return nil
@@ -189,7 +189,7 @@ func checkAllowedExtensions(exts ...string) check {
 			return nil
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error checking for allowed extensions: %w", err)
 		}
 		return issues, nil
 	}
@@ -210,7 +210,7 @@ func checkAllowedDirs(dirs ...string) check {
 		}
 		infos, err := f.Readdir(-1)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error reading directory: %w", err)
 		}
 
 		for _, fi := range infos {
@@ -241,11 +241,11 @@ func checkAllowedFiles(dirs ...string) check {
 
 		f, err := os.Open(dir)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error opening directory: %w", err)
 		}
 		infos, err := f.Readdir(-1)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error reading directory: %w", err)
 		}
 
 		for _, fi := range infos {

--- a/internal/tmplfuncs/tmplfuncs.go
+++ b/internal/tmplfuncs/tmplfuncs.go
@@ -2,7 +2,6 @@ package tmplfuncs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,7 +20,7 @@ func CodeFile(format, file string) (string, error) {
 	}
 
 	fullPath := filepath.Join(wd, file)
-	content, err := ioutil.ReadFile(fullPath)
+	content, err := os.ReadFile(fullPath)
 	if err != nil {
 		return "", fmt.Errorf("unable to read content from %q: %w", file, err)
 	}

--- a/internal/tmplfuncs/tmplfuncs.go
+++ b/internal/tmplfuncs/tmplfuncs.go
@@ -17,7 +17,7 @@ func CodeFile(format, file string) (string, error) {
 	// may be undesirable, probably need to think about it
 	wd, err := os.Getwd()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error getting working dir: %w", err)
 	}
 
 	fullPath := filepath.Join(wd, file)

--- a/schemamd/render.go
+++ b/schemamd/render.go
@@ -12,11 +12,12 @@ import (
 
 // Render writes a Markdown formatted Schema definition to the specified writer.
 // A Schema contains a Version and the root Block, for example:
-// "aws_accessanalyzer_analyzer": {
-//   "block": {
-//   },
-// 	 "version": 0
-// },
+//
+//	"aws_accessanalyzer_analyzer": {
+//	  "block": {
+//	  },
+//		 "version": 0
+//	},
 func Render(schema *tfjson.Schema, w io.Writer) error {
 	_, err := io.WriteString(w, "## Schema\n\n")
 	if err != nil {
@@ -178,26 +179,27 @@ func writeRootBlock(w io.Writer, block *tfjson.SchemaBlock) error {
 // * Description(Kind)
 // * Deprecated flag
 // For example:
-// "block": {
-//   "attributes": {
-//     "certificate_arn": {
-// 	     "description_kind": "plain",
-// 	     "required": true,
-// 	     "type": "string"
-//     }
-// 	 },
-// 	 "block_types": {
-//     "timeouts": {
-// 	     "block": {
-// 		   "attributes": {
-// 		   },
-// 		   "description_kind": "plain"
-// 	     },
-// 	     "nesting_mode": "single"
-//     }
-// 	 },
-// 	 "description_kind": "plain"
-// },
+//
+//	"block": {
+//	  "attributes": {
+//	    "certificate_arn": {
+//		     "description_kind": "plain",
+//		     "required": true,
+//		     "type": "string"
+//	    }
+//		 },
+//		 "block_types": {
+//	    "timeouts": {
+//		     "block": {
+//			   "attributes": {
+//			   },
+//			   "description_kind": "plain"
+//		     },
+//		     "nesting_mode": "single"
+//	    }
+//		 },
+//		 "description_kind": "plain"
+//	},
 func writeBlockChildren(w io.Writer, parents []string, block *tfjson.SchemaBlock, root bool) error {
 	names := []string{}
 	for n := range block.Attributes {
@@ -226,7 +228,7 @@ nameLoop:
 				//
 				// If a `.Description` is provided instead, the behaviour will be the
 				// same as for every other attribute.
-				if strings.ToLower(n) == "id" && childAtt.Description == "" {
+				if strings.EqualFold(n, "id") && childAtt.Description == "" {
 					if strings.Contains(gf.topLevelTitle, "Read-Only") {
 						childAtt.Description = "The ID of this resource."
 						groups[i] = append(groups[i], n)

--- a/schemamd/write_block_type_description.go
+++ b/schemamd/write_block_type_description.go
@@ -56,17 +56,15 @@ func WriteBlockTypeDescription(w io.Writer, block *tfjson.SchemaBlockType) error
 		default:
 			return fmt.Errorf("block does not match any filter states")
 		}
-	} else {
-		if block.MinItems > 0 {
-			_, err = io.WriteString(w, fmt.Sprintf(", Min: %d", block.MinItems))
-			if err != nil {
-				return err
-			}
+	} else if block.MinItems > 0 {
+		_, err = fmt.Fprintf(w, ", Min: %d", block.MinItems)
+		if err != nil {
+			return err
 		}
 	}
 
 	if block.MaxItems > 0 {
-		_, err = io.WriteString(w, fmt.Sprintf(", Max: %d", block.MaxItems))
+		_, err = fmt.Fprintf(w, ", Max: %d", block.MaxItems)
 		if err != nil {
 			return err
 		}

--- a/schemamd/write_nested_attribute_type_description.go
+++ b/schemamd/write_nested_attribute_type_description.go
@@ -66,7 +66,7 @@ func WriteNestedAttributeTypeDescription(w io.Writer, att *tfjson.SchemaAttribut
 		}
 	} else {
 		if nestedAttributeType.MinItems > 0 {
-			_, err = io.WriteString(w, fmt.Sprintf(", Min: %d", nestedAttributeType.MinItems))
+			_, err = fmt.Fprintf(w, ", Min: %d", nestedAttributeType.MinItems)
 			if err != nil {
 				return err
 			}
@@ -74,7 +74,7 @@ func WriteNestedAttributeTypeDescription(w io.Writer, att *tfjson.SchemaAttribut
 	}
 
 	if nestedAttributeType.MaxItems > 0 {
-		_, err = io.WriteString(w, fmt.Sprintf(", Max: %d", nestedAttributeType.MaxItems))
+		_, err = fmt.Fprintf(w, ", Max: %d", nestedAttributeType.MaxItems)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Hello! This PR has quite a few error related improvements, as well as fixes recommended from golangci-lint. If you'd like me to move the lint related fixes into another PR, I can do that as well.

List of changes:
- Wrapped quite a few errors, which helps track down the specific logic that had an issue, if a user receives an error.
- Configure `tfexec` to redirect `stderr` returned from the terraform CLI, back to the user. This will give context to errors like "configuration is invalid" where you can't tell what the error is.
  - This will very likely help users in these issues (it helped me when I received the same error):
    - https://github.com/hashicorp/terraform-plugin-docs/issues/169
    - https://github.com/hashicorp/terraform-plugin-docs/issues/167
    - https://github.com/hashicorp/terraform-plugin-docs/issues/136
- Migrated away from `io/ioutil` as it has been deprecated since Go 1.16.
- Fixed a few cases where errors were being masked and not properly handled.
- Added a golangci-lint configuration file (`.golang-ci.yml`), which will help with https://github.com/hashicorp/terraform-plugin-docs/issues/144.
- Simplified and cleaned up quite a few things based off recommendations from golangci-lint.

If there are any adjustments you'd like me to make, I'd be happy to!