### PR TITLE
Add subcategory support to the generate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Available commands are:
                 the generate command is run by default
     generate    generates a plugin website from code, templates, and examples for the current directory
     validate    validates a plugin website for the current directory
-       
+
 ```
 
 `generate` command:
@@ -39,14 +39,15 @@ $ tfplugindocs generate --help
 
 Usage: tfplugindocs generate [<args>]
 
-    --examples-dir <ARG>             examples directory                                                        (default: "examples")
-    --ignore-deprecated <ARG>        don't generate documentation for deprecated resources and data-sources    (default: "false")
-    --legacy-sidebar <ARG>           generate the legacy .erb sidebar file                                     (default: "false")
+    --examples-dir <ARG>             examples directory                                                                                                                                                   (default: "examples")
+    --ignore-deprecated <ARG>        don't generate documentation for deprecated resources and data-sources                                                                                               (default: "false")
+    --legacy-sidebar <ARG>           generate the legacy .erb sidebar file                                                                                                                                (default: "false")
     --provider-name <ARG>            provider name, as used in Terraform configurations
     --rendered-provider-name <ARG>   provider name, as generated in documentation (ex. page titles, ...)
-    --rendered-website-dir <ARG>     output directory                                                          (default: "docs")
+    --rendered-website-dir <ARG>     output directory                                                                                                                                                     (default: "docs")
+    --subcategory <ARG>              an optional subcategory mapping to group resources, can be specified multiple time e.g. --subcategory consul_acl=ACL --subcategory consul_admin="Admin Partition"
     --tf-version <ARG>               terraform binary version to download
-    --website-source-dir <ARG>       templates directory                                                       (default: "templates")
+    --website-source-dir <ARG>       templates directory                                                                                                                                                  (default: "templates")
     --website-temp-dir <ARG>         temporary directory (used during generation)
 ```
 
@@ -150,6 +151,7 @@ using the following data fields and functions:
 |------------------------:|:------:|-------------------------------------------------------------------------------------------|
 |                 `.Name` | string | Name of the resource/data-source (ex. `tls_certificate`)                                  |
 |                 `.Type` | string | Either `Resource` or `Data Source`                                                        |
+|          `.SubCategory` | string | The subcategory for this resource or an empty string if unset                             |
 |          `.Description` | string | Resource / Data Source description                                                        |
 |           `.HasExample` |  bool  | Is there an example file?                                                                 |
 |          `.ExampleFile` | string | Path to the file with the terraform configuration example                                 |

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -22,6 +22,7 @@ type generateCmd struct {
 	flagWebsiteTmpDir      string
 	flagWebsiteSourceDir   string
 	tfVersion              string
+	flagSubcategory        provider.SubCategories
 }
 
 func (cmd *generateCmd) Synopsis() string {
@@ -42,7 +43,7 @@ func (cmd *generateCmd) Help() string {
 		}
 	})
 
-	strBuilder.WriteString(fmt.Sprintf("\nUsage: tfplugindocs generate [<args>]\n\n"))
+	strBuilder.WriteString("\nUsage: tfplugindocs generate [<args>]\n\n")
 	cmd.Flags().VisitAll(func(f *flag.Flag) {
 		if f.DefValue != "" {
 			strBuilder.WriteString(fmt.Sprintf("    --%s <ARG> %s%s%s  (default: %q)\n",
@@ -67,6 +68,8 @@ func (cmd *generateCmd) Help() string {
 }
 
 func (cmd *generateCmd) Flags() *flag.FlagSet {
+	cmd.flagSubcategory = provider.SubCategories{}
+
 	fs := flag.NewFlagSet("generate", flag.ExitOnError)
 	fs.BoolVar(&cmd.flagLegacySidebar, "legacy-sidebar", false, "generate the legacy .erb sidebar file")
 	fs.StringVar(&cmd.flagProviderName, "provider-name", "", "provider name, as used in Terraform configurations")
@@ -77,6 +80,7 @@ func (cmd *generateCmd) Flags() *flag.FlagSet {
 	fs.StringVar(&cmd.flagWebsiteSourceDir, "website-source-dir", "templates", "templates directory")
 	fs.StringVar(&cmd.tfVersion, "tf-version", "", "terraform binary version to download")
 	fs.BoolVar(&cmd.flagIgnoreDeprecated, "ignore-deprecated", false, "don't generate documentation for deprecated resources and data-sources")
+	fs.Var(&cmd.flagSubcategory, "subcategory", "an optional subcategory mapping to group resources, can be specified multiple time e.g. --subcategory consul_acl=ACL --subcategory consul_admin=\"Admin Partition\"")
 	return fs
 }
 
@@ -103,6 +107,7 @@ func (cmd *generateCmd) runInternal() error {
 		cmd.flagWebsiteSourceDir,
 		cmd.tfVersion,
 		cmd.flagIgnoreDeprecated,
+		cmd.flagSubcategory,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to generate website: %w", err)

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -30,7 +30,7 @@ func (cmd *validateCmd) Help() string {
 		}
 	})
 
-	strBuilder.WriteString(fmt.Sprintf("\nUsage: tfplugindocs validate [<args>]\n\n"))
+	strBuilder.WriteString("\nUsage: tfplugindocs validate [<args>]\n\n")
 	cmd.Flags().VisitAll(func(f *flag.Flag) {
 		if f.DefValue != "" {
 			strBuilder.WriteString(fmt.Sprintf("    --%s <ARG> %s%s%s  (default: %q)\n",

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -165,7 +165,7 @@ func (t providerTemplate) Render(providerName, renderedProviderName, exampleFile
 	})
 }
 
-func (t resourceTemplate) Render(name, providerName, renderedProviderName, typeName, exampleFile, importFile string, schema *tfjson.Schema) (string, error) {
+func (t resourceTemplate) Render(name, providerName, renderedProviderName, typeName, subCategory, exampleFile, importFile string, schema *tfjson.Schema) (string, error) {
 	schemaBuffer := bytes.NewBuffer(nil)
 	err := schemamd.Render(schema, schemaBuffer)
 	if err != nil {
@@ -181,6 +181,7 @@ func (t resourceTemplate) Render(name, providerName, renderedProviderName, typeN
 		Type        string
 		Name        string
 		Description string
+		SubCategory string
 
 		HasExample  bool
 		ExampleFile string
@@ -198,6 +199,7 @@ func (t resourceTemplate) Render(name, providerName, renderedProviderName, typeN
 		Type:        typeName,
 		Name:        name,
 		Description: schema.Block.Description,
+		SubCategory: subCategory,
 
 		HasExample:  exampleFile != "" && fileExists(exampleFile),
 		ExampleFile: exampleFile,
@@ -217,7 +219,7 @@ func (t resourceTemplate) Render(name, providerName, renderedProviderName, typeN
 const defaultResourceTemplate resourceTemplate = `---
 ` + frontmatterComment + `
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "{{.SubCategory}}"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
@@ -246,7 +248,7 @@ Import is supported using the following syntax:
 const defaultProviderTemplate providerTemplate = `---
 ` + frontmatterComment + `
 page_title: "{{.ProviderShortName}} Provider"
-subcategory: ""
+subcategory: "{{.SubCategory}}"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---


### PR DESCRIPTION
This patch adds a --subcategory flag that let users give a mapping that will use to set the `subcategory` field in the documentation:

	tfplugindocs generate --subcategory consul_acl=ACL --subcategory consul_admin="Admin Partition"

The format for the flag is `prefix="Sub Category"` so all resources and datasources starting with `consul_acl` like `consul_acl_policy`, `consul_acl_token`, etc. will have the `subcategory: "ACL"` in the generated documentation. This is not very elegant but should work in most cases as needed.

Closes https://github.com/hashicorp/terraform-plugin-docs/issues/156