### PR TITLE
ci: add `golangci` linting + fixed deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:
           version: latest
+          args: --timeout=3m
       - name: go vet
         run: go vet ./...
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,13 @@ jobs:
     strategy:
       matrix:
         os:
-          # - ubuntu-latest
+          - ubuntu-latest
           - windows-latest
-          # - macos-latest
+          - macos-latest
     steps:
-      - name: CLRF handling test
+      # Related issue: https://github.com/golangci/golangci-lint/issues/580
+      - name: Ensure LF line endings for gofmt
+        if: matrix.os == 'windows-latest'
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
           - macos-latest
     steps:
       # Related issue: https://github.com/golangci/golangci-lint/issues/580
-      - name: Ensure LF line endings for gofmt
+      - name: Windows - ensure LF line endings for gofmt
         if: matrix.os == 'windows-latest'
         run: |
           git config --global core.autocrlf false
@@ -30,7 +30,7 @@ jobs:
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:
           version: latest
-          args: --timeout=3m -v
+          args: --timeout=3m
       - name: go vet
         run: go vet ./...
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ jobs:
           - windows-latest
           - macos-latest
     steps:
+      - name: CLRF handling test
+        run: |
+          git config --global core.autocrlf true
+
       - name: Check out code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - name: CLRF handling test
         run: |
-          git config --global core.autocrlf true
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       - name: Check out code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: 'go.mod'
+      - name: Run linters
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
+        with:
+          version: latest
       - name: go vet
         run: go vet ./...
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:
           version: latest
-          args: --timeout=3m
+          args: --timeout=3m -v
       - name: go vet
         run: go vet ./...
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          # - ubuntu-latest
           - windows-latest
-          - macos-latest
+          # - macos-latest
     steps:
       - name: CLRF handling test
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,25 @@
+issues:
+  max-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable:
+    - durationcheck
+    - errcheck
+    - exportloopref
+    - forcetypeassert
+    - gofmt
+    - gosimple
+    - ineffassign
+    - makezero
+    - misspell
+    - nilerr
+    - paralleltest
+    - predeclared
+    - staticcheck
+    - tenv
+    - unconvert
+    - unparam
+    - unused
+    - vet

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -42,7 +42,7 @@ func (cmd *generateCmd) Help() string {
 		}
 	})
 
-	strBuilder.WriteString(fmt.Sprintf("\nUsage: tfplugindocs generate [<args>]\n\n"))
+	strBuilder.WriteString("\nUsage: tfplugindocs generate [<args>]\n\n")
 	cmd.Flags().VisitAll(func(f *flag.Flag) {
 		if f.DefValue != "" {
 			strBuilder.WriteString(fmt.Sprintf("    --%s <ARG> %s%s%s  (default: %q)\n",

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -30,7 +30,7 @@ func (cmd *validateCmd) Help() string {
 		}
 	})
 
-	strBuilder.WriteString(fmt.Sprintf("\nUsage: tfplugindocs validate [<args>]\n\n"))
+	strBuilder.WriteString("\nUsage: tfplugindocs validate [<args>]\n\n")
 	cmd.Flags().VisitAll(func(f *flag.Flag) {
 		if f.DefValue != "" {
 			strBuilder.WriteString(fmt.Sprintf("    --%s <ARG> %s%s%s  (default: %q)\n",

--- a/internal/mdplain/renderer.go
+++ b/internal/mdplain/renderer.go
@@ -130,13 +130,9 @@ func (options *Text) Emphasis(out *bytes.Buffer, text []byte) {
 	out.Write(text)
 }
 
-func (options *Text) Image(out *bytes.Buffer, link []byte, title []byte, alt []byte) {
-	return
-}
+func (options *Text) Image(out *bytes.Buffer, link []byte, title []byte, alt []byte) {}
 
-func (options *Text) LineBreak(out *bytes.Buffer) {
-	return
-}
+func (options *Text) LineBreak(out *bytes.Buffer) {}
 
 func (options *Text) Link(out *bytes.Buffer, link []byte, title []byte, content []byte) {
 	out.Write(content)
@@ -144,12 +140,9 @@ func (options *Text) Link(out *bytes.Buffer, link []byte, title []byte, content 
 		out.WriteString(" ")
 		out.Write(link)
 	}
-	return
 }
 
-func (options *Text) RawHtmlTag(out *bytes.Buffer, text []byte) {
-	return
-}
+func (options *Text) RawHtmlTag(out *bytes.Buffer, text []byte) {}
 
 func (options *Text) TripleEmphasis(out *bytes.Buffer, text []byte) {
 	out.Write(text)
@@ -159,9 +152,7 @@ func (options *Text) StrikeThrough(out *bytes.Buffer, text []byte) {
 	out.Write(text)
 }
 
-func (options *Text) FootnoteRef(out *bytes.Buffer, ref []byte, id int) {
-	return
-}
+func (options *Text) FootnoteRef(out *bytes.Buffer, ref []byte, id int) {}
 
 func (options *Text) Entity(out *bytes.Buffer, entity []byte) {
 	out.Write(entity)
@@ -171,25 +162,15 @@ func (options *Text) NormalText(out *bytes.Buffer, text []byte) {
 	out.Write(text)
 }
 
-func (options *Text) Smartypants(out *bytes.Buffer, text []byte) {
-	return
-}
+func (options *Text) Smartypants(out *bytes.Buffer, text []byte) {}
 
-func (options *Text) DocumentHeader(out *bytes.Buffer) {
-	return
-}
+func (options *Text) DocumentHeader(out *bytes.Buffer) {}
 
-func (options *Text) DocumentFooter(out *bytes.Buffer) {
-	return
-}
+func (options *Text) DocumentFooter(out *bytes.Buffer) {}
 
-func (options *Text) TocHeader(text []byte, level int) {
-	return
-}
+func (options *Text) TocHeader(text []byte, level int) {}
 
-func (options *Text) TocFinalize() {
-	return
-}
+func (options *Text) TocFinalize() {}
 
 func doubleSpace(out *bytes.Buffer) {
 	if out.Len() > 0 {

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -128,7 +127,7 @@ func (g *generator) Generate(ctx context.Context) error {
 
 	switch {
 	case g.websiteTmpDir == "":
-		g.websiteTmpDir, err = ioutil.TempDir("", "tfws")
+		g.websiteTmpDir, err = os.MkdirTemp("", "tfws")
 		if err != nil {
 			return err
 		}
@@ -249,7 +248,7 @@ func (g *generator) renderMissingResourceDoc(providerName, name, typeName string
 	fallbackTmplPath = filepath.Join(g.websiteTmpDir, g.websiteSourceDir, fallbackTmplPath)
 	if fileExists(fallbackTmplPath) {
 		g.infof("resource %q fallback template exists", name)
-		tmplData, err := ioutil.ReadFile(fallbackTmplPath)
+		tmplData, err := os.ReadFile(fallbackTmplPath)
 		if err != nil {
 			return fmt.Errorf("unable to read file %q: %w", fallbackTmplPath, err)
 		}
@@ -377,7 +376,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 
 	g.infof("rendering templated website to static markdown")
 
-	err = filepath.Walk(g.websiteTmpDir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(g.websiteTmpDir, func(path string, info os.FileInfo, _ error) error {
 		if info.IsDir() {
 			// skip directories
 			return nil
@@ -410,7 +409,7 @@ func (g *generator) renderStaticWebsite(providerName string, providerSchema *tfj
 
 		renderedPath = strings.TrimSuffix(renderedPath, ext)
 
-		tmplData, err := ioutil.ReadFile(path)
+		tmplData, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("unable to read file %q: %w", rel, err)
 		}
@@ -492,7 +491,7 @@ func (g *generator) terraformProviderSchema(ctx context.Context, providerName st
 
 	shortName := providerShortName(providerName)
 
-	tmpDir, err := ioutil.TempDir("", "tfws")
+	tmpDir, err := os.MkdirTemp("", "tfws")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/template_test.go
+++ b/internal/provider/template_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestRenderStringTemplate(t *testing.T) {
+	t.Parallel()
+
 	template := `
 Plainmarkdown: {{ plainmarkdown .Text }}
 Split: {{ $arr := split .Text " "}}{{ index $arr 3 }}

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -78,7 +77,7 @@ func writeFile(path string, data string) error {
 		return fmt.Errorf("unable to make dir %q: %w", dir, err)
 	}
 
-	err = ioutil.WriteFile(path, []byte(data), 0644)
+	err = os.WriteFile(path, []byte(data), 0644)
 	if err != nil {
 		return fmt.Errorf("unable to write file %q: %w", path, err)
 	}
@@ -90,7 +89,7 @@ func runCmd(cmd *exec.Cmd) ([]byte, error) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Printf("error executing %q, %v", cmd.Path, cmd.Args)
-		log.Printf(string(output))
+		log.Print(string(output))
 		return nil, fmt.Errorf("error executing %q: %w", cmd.Path, err)
 	}
 	return output, nil

--- a/internal/provider/util_test.go
+++ b/internal/provider/util_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func Test_resourceSchema(t *testing.T) {
+	t.Parallel()
+
 	cases := map[string]struct {
 		schemas              map[string]*tfjson.Schema
 		providerShortName    string
@@ -63,7 +65,11 @@ func Test_resourceSchema(t *testing.T) {
 	}
 
 	for name, c := range cases {
+		name := name
+		c := c
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			actualSchema, actualResourceName := resourceSchema(c.schemas, c.providerShortName, c.templateFileName)
 
 			if !cmp.Equal(c.expectedSchema, actualSchema) {

--- a/internal/tmplfuncs/tmplfuncs.go
+++ b/internal/tmplfuncs/tmplfuncs.go
@@ -2,7 +2,6 @@ package tmplfuncs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,7 +20,7 @@ func CodeFile(format, file string) (string, error) {
 	}
 
 	fullPath := filepath.Join(wd, file)
-	content, err := ioutil.ReadFile(fullPath)
+	content, err := os.ReadFile(fullPath)
 	if err != nil {
 		return "", fmt.Errorf("unable to read content from %q: %w", file, err)
 	}

--- a/schemamd/behaviors_test.go
+++ b/schemamd/behaviors_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestChildAttributeIsRequired(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		name     string
 		att      *tfjson.SchemaAttribute
@@ -33,7 +35,10 @@ func TestChildAttributeIsRequired(t *testing.T) {
 			false,
 		},
 	} {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := childAttributeIsRequired(c.att)
 			if diff := cmp.Diff(c.expected, actual); diff != "" {
 				t.Fatalf("Unexpected diff (-wanted, +got): %s", diff)
@@ -43,6 +48,8 @@ func TestChildAttributeIsRequired(t *testing.T) {
 }
 
 func TestChildAttributeIsOptional(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		name     string
 		att      *tfjson.SchemaAttribute
@@ -67,7 +74,10 @@ func TestChildAttributeIsOptional(t *testing.T) {
 			true,
 		},
 	} {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := childAttributeIsOptional(c.att)
 			if diff := cmp.Diff(c.expected, actual); diff != "" {
 				t.Fatalf("Unexpected diff (-wanted, +got): %s", diff)
@@ -77,6 +87,8 @@ func TestChildAttributeIsOptional(t *testing.T) {
 }
 
 func TestChildAttributeIsReadOnly(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		name     string
 		att      *tfjson.SchemaAttribute
@@ -119,7 +131,10 @@ func TestChildAttributeIsReadOnly(t *testing.T) {
 			true,
 		},
 	} {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := childAttributeIsReadOnly(c.att)
 			if diff := cmp.Diff(c.expected, actual); diff != "" {
 				t.Fatalf("Unexpected diff (-wanted, +got): %s", diff)
@@ -129,6 +144,8 @@ func TestChildAttributeIsReadOnly(t *testing.T) {
 }
 
 func TestChildBlockIsRequired(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		name     string
 		block    *tfjson.SchemaBlockType
@@ -170,7 +187,10 @@ func TestChildBlockIsRequired(t *testing.T) {
 			false,
 		},
 	} {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := childBlockIsRequired(c.block)
 			if diff := cmp.Diff(c.expected, actual); diff != "" {
 				t.Fatalf("Unexpected diff (-wanted, +got): %s", diff)
@@ -180,6 +200,8 @@ func TestChildBlockIsRequired(t *testing.T) {
 }
 
 func TestChildBlockIsOptional(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		name     string
 		block    *tfjson.SchemaBlockType
@@ -335,7 +357,10 @@ func TestChildBlockIsOptional(t *testing.T) {
 			true,
 		},
 	} {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := childBlockIsOptional(c.block)
 			if diff := cmp.Diff(c.expected, actual); diff != "" {
 				t.Fatalf("Unexpected diff (-wanted, +got): %s", diff)
@@ -345,6 +370,8 @@ func TestChildBlockIsOptional(t *testing.T) {
 }
 
 func TestChildBlockIsReadOnly(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		name     string
 		block    *tfjson.SchemaBlockType
@@ -490,7 +517,10 @@ func TestChildBlockIsReadOnly(t *testing.T) {
 			true,
 		},
 	} {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := childBlockIsReadOnly(c.block)
 			if diff := cmp.Diff(c.expected, actual); diff != "" {
 				t.Fatalf("Unexpected diff (-wanted, +got): %s", diff)

--- a/schemamd/render.go
+++ b/schemamd/render.go
@@ -12,11 +12,12 @@ import (
 
 // Render writes a Markdown formatted Schema definition to the specified writer.
 // A Schema contains a Version and the root Block, for example:
-// "aws_accessanalyzer_analyzer": {
-//   "block": {
-//   },
-// 	 "version": 0
-// },
+//
+//	"aws_accessanalyzer_analyzer": {
+//	  "block": {
+//	  },
+//		 "version": 0
+//	},
 func Render(schema *tfjson.Schema, w io.Writer) error {
 	_, err := io.WriteString(w, "## Schema\n\n")
 	if err != nil {
@@ -178,26 +179,27 @@ func writeRootBlock(w io.Writer, block *tfjson.SchemaBlock) error {
 // * Description(Kind)
 // * Deprecated flag
 // For example:
-// "block": {
-//   "attributes": {
-//     "certificate_arn": {
-// 	     "description_kind": "plain",
-// 	     "required": true,
-// 	     "type": "string"
-//     }
-// 	 },
-// 	 "block_types": {
-//     "timeouts": {
-// 	     "block": {
-// 		   "attributes": {
-// 		   },
-// 		   "description_kind": "plain"
-// 	     },
-// 	     "nesting_mode": "single"
-//     }
-// 	 },
-// 	 "description_kind": "plain"
-// },
+//
+//	"block": {
+//	  "attributes": {
+//	    "certificate_arn": {
+//		     "description_kind": "plain",
+//		     "required": true,
+//		     "type": "string"
+//	    }
+//		 },
+//		 "block_types": {
+//	    "timeouts": {
+//		     "block": {
+//			   "attributes": {
+//			   },
+//			   "description_kind": "plain"
+//		     },
+//		     "nesting_mode": "single"
+//	    }
+//		 },
+//		 "description_kind": "plain"
+//	},
 func writeBlockChildren(w io.Writer, parents []string, block *tfjson.SchemaBlock, root bool) error {
 	names := []string{}
 	for n := range block.Attributes {

--- a/schemamd/render_test.go
+++ b/schemamd/render_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRender(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		name         string
 		inputFile    string
@@ -38,7 +40,10 @@ func TestRender(t *testing.T) {
 			"testdata/awscc_acmpca_certificate.md",
 		},
 	} {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			input, err := os.ReadFile(c.inputFile)
 			if err != nil {
 				t.Fatal(err)

--- a/schemamd/write_attribute_description_test.go
+++ b/schemamd/write_attribute_description_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestWriteAttributeDescription(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		expected string
 		att      *tfjson.SchemaAttribute
@@ -149,7 +151,10 @@ func TestWriteAttributeDescription(t *testing.T) {
 			},
 		},
 	} {
+		c := c
 		t.Run(c.expected, func(t *testing.T) {
+			t.Parallel()
+
 			b := &strings.Builder{}
 			err := schemamd.WriteAttributeDescription(b, c.att, true)
 			if err != nil {

--- a/schemamd/write_block_type_description_test.go
+++ b/schemamd/write_block_type_description_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestWriteBlockTypeDescription(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		expected string
 		bt       *tfjson.SchemaBlockType
@@ -213,7 +215,10 @@ func TestWriteBlockTypeDescription(t *testing.T) {
 			},
 		},
 	} {
+		c := c
 		t.Run(c.expected, func(t *testing.T) {
+			t.Parallel()
+
 			b := &strings.Builder{}
 			err := schemamd.WriteBlockTypeDescription(b, c.bt)
 			if err != nil {

--- a/schemamd/write_nested_attribute_type_description_test.go
+++ b/schemamd/write_nested_attribute_type_description_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestWriteNestedAttributeTypeDescription(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		expected string
 		att      *tfjson.SchemaAttribute
@@ -85,7 +87,10 @@ func TestWriteNestedAttributeTypeDescription(t *testing.T) {
 			},
 		},
 	} {
+		c := c
 		t.Run(c.expected, func(t *testing.T) {
+			t.Parallel()
+
 			b := &strings.Builder{}
 			err := schemamd.WriteNestedAttributeTypeDescription(b, c.att, true)
 			if err != nil {

--- a/schemamd/write_type_test.go
+++ b/schemamd/write_type_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestWriteType(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []struct {
 		expected string
 		ty       cty.Type
@@ -44,7 +46,10 @@ func TestWriteType(t *testing.T) {
 			"bool": cty.Bool,
 		}))))},
 	} {
+		c := c
 		t.Run(fmt.Sprintf("%s %s", c.ty.FriendlyName(), c.expected), func(t *testing.T) {
+			t.Parallel()
+
 			b := &strings.Builder{}
 			err := schemamd.WriteType(b, c.ty)
 			if err != nil {


### PR DESCRIPTION
contributes to:
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/102
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/83
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/126

### Notes
- Fixed deprecation of `ioutil` in favor of `os` std package
