### PR TITLE
Bump `terraform-exec` to `v0.18.1`

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230301-091541.yaml
+++ b/.changes/unreleased/BUG FIXES-20230301-091541.yaml
@@ -1,7 +1,7 @@
 kind: BUG FIXES
 body: 'dependencies: `github.com/hashicorp/terraform-exec` dependency upgraded to
   `v0.18.1` to avoid causing acceptance test failures when `terraform-plugin-sdk`
-  or `terraform-plugin-testing` is in use'
+  or `terraform-plugin-testing` are in use'
 time: 2023-03-01T09:15:41.520975-05:00
 custom:
   Issue: "226"

--- a/.changes/unreleased/BUG FIXES-20230301-091541.yaml
+++ b/.changes/unreleased/BUG FIXES-20230301-091541.yaml
@@ -1,0 +1,7 @@
+kind: BUG FIXES
+body: 'dependencies: `github.com/hashicorp/terraform-exec` dependency upgraded to
+  `v0.18.1` to avoid causing acceptance test failures when `terraform-plugin-sdk`
+  or `terraform-plugin-testing` is in use'
+time: 2023-03-01T09:15:41.520975-05:00
+custom:
+  Issue: "226"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.5.0
-	github.com/hashicorp/terraform-exec v0.18.0
+	github.com/hashicorp/terraform-exec v0.18.1
 	github.com/hashicorp/terraform-json v0.15.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/hc-install v0.5.0 h1:D9bl4KayIYKEeJ4vUDe9L5huqxZXczKaykSRcmQ0xY0=
 github.com/hashicorp/hc-install v0.5.0/go.mod h1:JyzMfbzfSBSjoDCRPna1vi/24BEDxFaCPfdHtM5SCdo=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-exec v0.18.0 h1:BJa6/Fhxnb0zvsEGqUrFSybcnhAiBVSUgG7s09b6XlI=
-github.com/hashicorp/terraform-exec v0.18.0/go.mod h1:6PMRgg0Capig5Fn0zW9/+WM3vQsdwotwa8uxDVzLpHE=
+github.com/hashicorp/terraform-exec v0.18.1 h1:LAbfDvNQU1l0NOQlTuudjczVhHj061fNX5H8XZxHlH4=
+github.com/hashicorp/terraform-exec v0.18.1/go.mod h1:58wg4IeuAJ6LVsLUeD2DWZZoc/bYi6dzhLHzxM41980=
 github.com/hashicorp/terraform-json v0.15.0 h1:/gIyNtR6SFw6h5yzlbDbACyGvIhKtQi8mTsbkNd79lE=
 github.com/hashicorp/terraform-json v0.15.0/go.mod h1:+L1RNzjDU5leLFZkHTFTbJXaoqUC6TqXlFgDoOXrtvk=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=


### PR DESCRIPTION
Closes #228 

## Background
A recent update of `tfexec` [v0.18.0](https://github.com/hashicorp/terraform-exec/releases/tag/v0.18.0) caused a regression where detailed stderr information wasn't being passed to downstream modules. This has now been fixed with the new release [v0.18.1](https://github.com/hashicorp/terraform-exec/releases/tag/v0.18.1)

While the docs tool doesn't use this error information directly, this caused a situation where upgrading `terraform-plugin-docs` from `0.13.0` to `0.14.0` could cause acceptance tests to fail if the consuming module also uses `terraform-plugin-testing` or `terraform-plugin-sdk`.

**Examples:**
- https://github.com/hashicorp/terraform-provider-tls/pull/327
- https://github.com/hashicorp/terraform-provider-tls/actions/runs/4296411115