### PR TITLE
generate: Remove legacy-sidebar flag

### DIFF
--- a/.changes/unreleased/BREAKING CHANGES-20230606-092955.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-20230606-092955.yaml
@@ -1,0 +1,6 @@
+kind: BREAKING CHANGES
+body: 'generate: The `legacy-sidebar` flag has been removed without replacement. It
+  implemented no logic and is not necessary with Terraform Registry based documentation'
+time: 2023-06-06T09:29:55.309657-04:00
+custom:
+  Issue: "258"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Usage: tfplugindocs generate [<args>]
 
     --examples-dir <ARG>             examples directory                                                        (default: "examples")
     --ignore-deprecated <ARG>        don't generate documentation for deprecated resources and data-sources    (default: "false")
-    --legacy-sidebar <ARG>           generate the legacy .erb sidebar file                                     (default: "false")
     --provider-name <ARG>            provider name, as used in Terraform configurations
     --rendered-provider-name <ARG>   provider name, as generated in documentation (ex. page titles, ...)
     --rendered-website-dir <ARG>     output directory                                                          (default: "docs")

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -14,7 +14,6 @@ import (
 type generateCmd struct {
 	commonCmd
 
-	flagLegacySidebar    bool
 	flagIgnoreDeprecated bool
 
 	flagProviderName         string
@@ -71,7 +70,6 @@ func (cmd *generateCmd) Help() string {
 
 func (cmd *generateCmd) Flags() *flag.FlagSet {
 	fs := flag.NewFlagSet("generate", flag.ExitOnError)
-	fs.BoolVar(&cmd.flagLegacySidebar, "legacy-sidebar", false, "generate the legacy .erb sidebar file")
 	fs.StringVar(&cmd.flagProviderName, "provider-name", "", "provider name, as used in Terraform configurations")
 	fs.StringVar(&cmd.flagRenderedProviderName, "rendered-provider-name", "", "provider name, as generated in documentation (ex. page titles, ...)")
 	fs.StringVar(&cmd.flagRenderedWebsiteDir, "rendered-website-dir", "docs", "output directory")
@@ -97,7 +95,6 @@ func (cmd *generateCmd) Run(args []string) int {
 func (cmd *generateCmd) runInternal() error {
 	err := provider.Generate(
 		cmd.ui,
-		cmd.flagLegacySidebar,
 		cmd.flagProviderName,
 		cmd.flagRenderedProviderName,
 		cmd.flagRenderedWebsiteDir,

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -67,7 +67,6 @@ var (
 
 type generator struct {
 	ignoreDeprecated bool
-	legacySidebar    bool
 	tfVersion        string
 
 	providerName         string
@@ -88,10 +87,9 @@ func (g *generator) warnf(format string, a ...interface{}) {
 	g.ui.Warn(fmt.Sprintf(format, a...))
 }
 
-func Generate(ui cli.Ui, legacySidebar bool, providerName, renderedProviderName, renderedWebsiteDir, examplesDir, websiteTmpDir, websiteSourceDir, tfVersion string, ignoreDeprecated bool) error {
+func Generate(ui cli.Ui, providerName, renderedProviderName, renderedWebsiteDir, examplesDir, websiteTmpDir, websiteSourceDir, tfVersion string, ignoreDeprecated bool) error {
 	g := &generator{
 		ignoreDeprecated: ignoreDeprecated,
-		legacySidebar:    legacySidebar,
 		tfVersion:        tfVersion,
 
 		providerName:         providerName,
@@ -183,12 +181,6 @@ func (g *generator) Generate(ctx context.Context) error {
 	err = g.renderStaticWebsite(providerName, providerSchema)
 	if err != nil {
 		return err
-	}
-
-	// TODO: may not ever need this, unsure on when this will go live
-	if g.legacySidebar {
-		g.infof("rendering legacy sidebar...")
-		g.warnf("TODO...!")
 	}
 
 	return nil


### PR DESCRIPTION
The "legacy sidebar" file was an `.erb` file that was used to render the side navigation when provider documentation was centrally gathered and hosted on the terraform.io website. Since the introduction of the public Terraform Registry, the side navigation is determined via the `subcategory` property in YAML frontmatter of documentation pages. The flag, which never actually implemented any logic and instead logged a "TODO" warning, is extremely unlikely to be used anywhere in practice.