### PR TITLE
ci: Set golangci-lint run timeout to 5 minutes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,3 +23,7 @@ linters:
     - unparam
     - unused
     - vet
+
+run:
+  # Prevent false positive timeouts in CI
+  timeout: 5m


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-docs/actions/runs/5191760369/jobs/9360009612
Reference: https://github.com/hashicorp/terraform-plugin-framework/blob/1e82228e6631748852c4cd00b6c7e1c0c1a4cfc2/.golangci.yml#L27-L29

Similar to other terraform-plugin-* repositories.