### PR TITLE
Removing dependabot github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: "daily"
-
   # Maintain dependencies for Go modules
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
Removing dependabot github actions in preparation for TSCCR automation.