### PR TITLE
Refactor `mdplain` package to use `yuin/goldmark` library for markdown processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/hashicorp/terraform-json v0.21.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/rogpeppe/go-internal v1.12.0
-	github.com/russross/blackfriday v1.6.0
 	github.com/yuin/goldmark v1.6.0
 	github.com/yuin/goldmark-meta v1.1.0
 	github.com/zclconf/go-cty v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,6 @@ github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXq
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
-github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
-github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=

--- a/internal/mdplain/mdplain.go
+++ b/internal/mdplain/mdplain.go
@@ -3,13 +3,25 @@
 
 package mdplain
 
-import "github.com/russross/blackfriday"
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+)
 
 // Clean runs a VERY naive cleanup of markdown text to make it more palatable as plain text.
-func PlainMarkdown(md string) (string, error) {
-	pt := &Text{}
-
-	html := blackfriday.MarkdownOptions([]byte(md), pt, blackfriday.Options{})
-
-	return string(html), nil
+func PlainMarkdown(markdown string) (string, error) {
+	var buf bytes.Buffer
+	extensions := []goldmark.Extender{
+		extension.Linkify,
+	}
+	md := goldmark.New(
+		goldmark.WithExtensions(extensions...),
+		goldmark.WithRenderer(NewTextRenderer()),
+	)
+	if err := md.Convert([]byte(markdown), &buf); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }

--- a/internal/mdplain/mdplain_test.go
+++ b/internal/mdplain/mdplain_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package mdplain
 
 import (

--- a/internal/mdplain/mdplain_test.go
+++ b/internal/mdplain/mdplain_test.go
@@ -1,0 +1,35 @@
+package mdplain
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPlainMarkdown(t *testing.T) {
+	t.Parallel()
+
+	input, err := os.ReadFile("testdata/markdown.md")
+	if err != nil {
+		t.Errorf("Error opening file: %s", err.Error())
+		return
+	}
+
+	expectedFile, err := os.ReadFile("testdata/mdplain.txt")
+	if err != nil {
+		t.Errorf("Error opening file: %s", err.Error())
+		return
+	}
+
+	expected := string(expectedFile)
+	actual, err := PlainMarkdown(string(input))
+	if err != nil {
+		t.Errorf("Error rendering markdown: %s", err.Error())
+		return
+	}
+	if !cmp.Equal(expected, actual) {
+		t.Errorf(cmp.Diff(expected, actual))
+	}
+
+}

--- a/internal/mdplain/renderer.go
+++ b/internal/mdplain/renderer.go
@@ -5,175 +5,98 @@ package mdplain
 
 import (
 	"bytes"
+	"io"
 
-	"github.com/russross/blackfriday"
+	"github.com/yuin/goldmark/ast"
+	extAST "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/renderer"
 )
 
-type Text struct{}
+type TextRender struct{}
 
-func TextRenderer() blackfriday.Renderer {
-	return &Text{}
+func NewTextRenderer() *TextRender {
+	return &TextRender{}
 }
 
-func (options *Text) GetFlags() int {
-	return 0
-}
+func (r *TextRender) Render(w io.Writer, source []byte, n ast.Node) error {
+	out := bytes.NewBuffer([]byte{})
+	err := ast.Walk(n, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering || node.Type() == ast.TypeDocument {
+			return ast.WalkContinue, nil
+		}
 
-func (options *Text) TitleBlock(out *bytes.Buffer, text []byte) {
-	text = bytes.TrimPrefix(text, []byte("% "))
-	text = bytes.Replace(text, []byte("\n% "), []byte("\n"), -1)
-	out.Write(text)
-	out.WriteString("\n")
-}
+		switch node := node.(type) {
+		case *ast.Blockquote, *ast.Heading:
+			doubleSpace(out)
+			out.Write(node.Text(source))
+			return ast.WalkSkipChildren, nil
+		case *ast.ThematicBreak:
+			doubleSpace(out)
+			return ast.WalkSkipChildren, nil
+		case *ast.CodeBlock:
+			doubleSpace(out)
+			for i := 0; i < node.Lines().Len(); i++ {
+				line := node.Lines().At(i)
+				out.Write(line.Value(source))
+			}
+			return ast.WalkSkipChildren, nil
+		case *ast.FencedCodeBlock:
+			doubleSpace(out)
+			doubleSpace(out)
+			for i := 0; i < node.Lines().Len(); i++ {
+				line := node.Lines().At(i)
+				_, _ = out.Write(line.Value(source))
+			}
+			return ast.WalkSkipChildren, nil
+		case *ast.List:
+			doubleSpace(out)
+			return ast.WalkContinue, nil
+		case *ast.Paragraph:
+			doubleSpace(out)
+			if node.Text(source)[0] == '|' { // Write tables as-is.
+				for i := 0; i < node.Lines().Len(); i++ {
+					line := node.Lines().At(i)
+					out.Write(line.Value(source))
+				}
+				return ast.WalkSkipChildren, nil
+			}
+			return ast.WalkContinue, nil
+		case *ast.AutoLink, *extAST.Strikethrough:
+			out.Write(node.Text(source))
+			return ast.WalkContinue, nil
+		case *ast.CodeSpan:
+			out.Write(node.Text(source))
+			return ast.WalkSkipChildren, nil
+		case *ast.Link:
+			_, err := out.Write(node.Text(source))
+			if !isRelativeLink(node.Destination) {
+				out.WriteString(" ")
+				out.Write(node.Destination)
+			}
+			return ast.WalkSkipChildren, err
+		case *ast.Text:
+			out.Write(node.Text(source))
+			if node.SoftLineBreak() {
+				doubleSpace(out)
+			}
+			return ast.WalkContinue, nil
+		case *ast.Image:
+			return ast.WalkSkipChildren, nil
 
-func (options *Text) Header(out *bytes.Buffer, text func() bool, level int, id string) {
-	marker := out.Len()
-	doubleSpace(out)
-
-	if !text() {
-		out.Truncate(marker)
-		return
+		}
+		return ast.WalkContinue, nil
+	})
+	if err != nil {
+		return err
 	}
-}
-
-func (options *Text) BlockHtml(out *bytes.Buffer, text []byte) {
-	doubleSpace(out)
-	out.Write(text)
-	out.WriteByte('\n')
-}
-
-func (options *Text) HRule(out *bytes.Buffer) {
-	doubleSpace(out)
-}
-
-func (options *Text) BlockCode(out *bytes.Buffer, text []byte, lang string) {
-	options.BlockCodeNormal(out, text, lang)
-}
-
-func (options *Text) BlockCodeNormal(out *bytes.Buffer, text []byte, lang string) {
-	doubleSpace(out)
-	out.Write(text)
-}
-
-func (options *Text) BlockQuote(out *bytes.Buffer, text []byte) {
-	doubleSpace(out)
-	out.Write(text)
-}
-
-func (options *Text) Table(out *bytes.Buffer, header []byte, body []byte, columnData []int) {
-	doubleSpace(out)
-	out.Write(header)
-	out.Write(body)
-}
-
-func (options *Text) TableRow(out *bytes.Buffer, text []byte) {
-	doubleSpace(out)
-	out.Write(text)
-}
-
-func (options *Text) TableHeaderCell(out *bytes.Buffer, text []byte, align int) {
-	doubleSpace(out)
-	out.Write(text)
-}
-
-func (options *Text) TableCell(out *bytes.Buffer, text []byte, align int) {
-	doubleSpace(out)
-	out.Write(text)
-}
-
-func (options *Text) Footnotes(out *bytes.Buffer, text func() bool) {
-	options.HRule(out)
-	options.List(out, text, 0)
-}
-
-func (options *Text) FootnoteItem(out *bytes.Buffer, name, text []byte, flags int) {
-	out.Write(text)
-}
-
-func (options *Text) List(out *bytes.Buffer, text func() bool, flags int) {
-	marker := out.Len()
-	doubleSpace(out)
-
-	if !text() {
-		out.Truncate(marker)
-		return
+	_, err = w.Write(out.Bytes())
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
-func (options *Text) ListItem(out *bytes.Buffer, text []byte, flags int) {
-	out.Write(text)
-}
-
-func (options *Text) Paragraph(out *bytes.Buffer, text func() bool) {
-	marker := out.Len()
-	doubleSpace(out)
-
-	if !text() {
-		out.Truncate(marker)
-		return
-	}
-}
-
-func (options *Text) AutoLink(out *bytes.Buffer, link []byte, kind int) {
-	out.Write(link)
-}
-
-func (options *Text) CodeSpan(out *bytes.Buffer, text []byte) {
-	out.Write(text)
-}
-
-func (options *Text) DoubleEmphasis(out *bytes.Buffer, text []byte) {
-	out.Write(text)
-}
-
-func (options *Text) Emphasis(out *bytes.Buffer, text []byte) {
-	if len(text) == 0 {
-		return
-	}
-	out.Write(text)
-}
-
-func (options *Text) Image(out *bytes.Buffer, link []byte, title []byte, alt []byte) {}
-
-func (options *Text) LineBreak(out *bytes.Buffer) {}
-
-func (options *Text) Link(out *bytes.Buffer, link []byte, title []byte, content []byte) {
-	out.Write(content)
-	if !isRelativeLink(link) {
-		out.WriteString(" ")
-		out.Write(link)
-	}
-}
-
-func (options *Text) RawHtmlTag(out *bytes.Buffer, text []byte) {}
-
-func (options *Text) TripleEmphasis(out *bytes.Buffer, text []byte) {
-	out.Write(text)
-}
-
-func (options *Text) StrikeThrough(out *bytes.Buffer, text []byte) {
-	out.Write(text)
-}
-
-func (options *Text) FootnoteRef(out *bytes.Buffer, ref []byte, id int) {}
-
-func (options *Text) Entity(out *bytes.Buffer, entity []byte) {
-	out.Write(entity)
-}
-
-func (options *Text) NormalText(out *bytes.Buffer, text []byte) {
-	out.Write(text)
-}
-
-func (options *Text) Smartypants(out *bytes.Buffer, text []byte) {}
-
-func (options *Text) DocumentHeader(out *bytes.Buffer) {}
-
-func (options *Text) DocumentFooter(out *bytes.Buffer) {}
-
-func (options *Text) TocHeader(text []byte, level int) {}
-
-func (options *Text) TocFinalize() {}
+func (r *TextRender) AddOptions(...renderer.Option) {}
 
 func doubleSpace(out *bytes.Buffer) {
 	if out.Len() > 0 {

--- a/internal/mdplain/testdata/markdown.md
+++ b/internal/mdplain/testdata/markdown.md
@@ -1,0 +1,120 @@
+# Markdown Cheat Sheet
+
+This is a slightly modified version of The Markdown Guide's [Markdown Cheat Sheet](https://www.markdownguide.org/cheat-sheet)!
+
+## Basic Syntax
+
+These are the elements outlined in John Gruber’s original design document. All Markdown applications support these elements.
+
+### Heading
+
+# H1
+## H2
+### H3
+
+### Bold
+
+**bold text**
+
+### Italic
+
+*italicized text*
+
+### Blockquote
+
+> blockquote
+
+### Ordered List
+
+1. First item
+2. Second item
+3. Third item
+
+### Unordered List
+
+- First item
+- Second item
+- Third item
+
+### Code
+
+`code`
+
+### Horizontal Rule
+
+---
+
+### Link
+
+[Markdown Guide](https://www.markdownguide.org)
+
+[Relative Link](#Code)
+
+
+### Image
+
+![alt text](https://www.markdownguide.org/assets/images/tux.png)
+
+## Extended Syntax
+
+These elements extend the basic syntax by adding additional features. Not all Markdown applications support these elements.
+
+### Table
+
+| Syntax | Description |
+| ----------- | ----------- |
+| Header | Title |
+| Paragraph | Text |
+
+### Fenced Code Block
+
+```
+{
+  "firstName": "John",
+  "lastName": "Smith",
+  "age": 25
+}
+```
+
+### Footnote
+
+Here's a sentence with a footnote. [^1]
+
+[^1]: This is the footnote.
+
+### Heading ID
+
+### My Great Heading {#custom-id}
+
+### Definition List
+
+term
+: definition
+
+### Strikethrough
+
+~~The world is flat.~~
+
+### Task List
+
+- [x] Write the press release
+- [ ] Update the website
+- [ ] Contact the media
+
+### Emoji
+
+That is so funny! :joy:
+
+(See also [Copying and Pasting Emoji](https://www.markdownguide.org/extended-syntax/#copying-and-pasting-emoji))
+
+### Highlight
+
+I need to highlight these ==very important words==.
+
+### Subscript
+
+H~2~O
+
+### Superscript
+
+X^2^

--- a/internal/mdplain/testdata/mdplain.txt
+++ b/internal/mdplain/testdata/mdplain.txt
@@ -1,0 +1,63 @@
+Markdown Cheat Sheet
+This is a slightly modified version of The Markdown Guide's Markdown Cheat Sheet https://www.markdownguide.org/cheat-sheet!
+Basic Syntax
+These are the elements outlined in John Gruber’s original design document. All Markdown applications support these elements.
+Heading
+H1
+H2
+H3
+Bold
+bold text
+Italic
+italicized text
+Blockquote
+blockquote
+Ordered List
+First itemSecond itemThird item
+Unordered List
+First itemSecond itemThird item
+Code
+code
+Horizontal Rule
+
+Link
+Markdown Guide https://www.markdownguide.org
+Relative Link
+Image
+
+Extended Syntax
+These elements extend the basic syntax by adding additional features. Not all Markdown applications support these elements.
+Table
+| Syntax | Description |
+| ----------- | ----------- |
+| Header | Title |
+| Paragraph | Text |
+Fenced Code Block
+
+{
+  "firstName": "John",
+  "lastName": "Smith",
+  "age": 25
+}
+
+Footnote
+Here's a sentence with a footnote. [^1]
+[^1]: This is the footnote.
+Heading ID
+My Great Heading {#custom-id}
+Definition List
+term
+: definition
+Strikethrough
+~~The world is flat.~~
+Task List
+[x] Write the press release[ ] Update the website[ ] Contact the media
+Emoji
+That is so funny! :joy:
+(See also Copying and Pasting Emoji https://www.markdownguide.org/extended-syntax/#copying-and-pasting-emoji)
+Highlight
+I need to highlight these ==very important words==.
+Subscript
+H~2~O
+Superscript
+X^2^


### PR DESCRIPTION
Closes: #321 

This PR adds a golden file test for the `PlainMarkdown()` function and refactors the `mdplain` package to use `yuin/goldmark` library instead of `russross/blackfriday` for markdown processing.