### PR TITLE
support provider prefix in generated filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ The `migrate` subcommand takes the following actions:
 
 The generation of missing documentation is based on a number of assumptions / conventional paths.
 
-> **NOTE:** In the following conventional paths, `<data source name>` and `<resource name>` include the provider prefix as well, but the provider prefix is **NOT** included in`<function name>`.
-> For example, the data source [`caller_identity`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) in the `aws` provider would have an "example" conventional path of: `examples/data-sources/aws_caller_identity/data-source.tf`
+> **NOTE:** In the following conventional paths, `<data source name>`, `<resource name>`, and `<function name>` **DO NOT**include the provider prefix; if `--use-provider-prefix=true` is specified, the provider prefix is included in `<data source name>` and `<resource name>` but it is **NOT** included in`<function name>`.
+> For example, the data source [`caller_identity`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) in the `aws` provider would have an "example" conventional path of `examples/data-sources/caller_identity/data-source.tf` by default, and `examples/data-sources/aws_caller_identity/data-source.tf` if `--use-provider-prefix=true` is specified.
 
 For templates:
 

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -14,7 +14,8 @@ import (
 type generateCmd struct {
 	commonCmd
 
-	flagIgnoreDeprecated bool
+	flagIgnoreDeprecated  bool
+	flagUseProviderPrefix bool
 
 	flagProviderName         string
 	flagRenderedProviderName string
@@ -82,6 +83,7 @@ func (cmd *generateCmd) Flags() *flag.FlagSet {
 	fs.StringVar(&cmd.flagWebsiteSourceDir, "website-source-dir", "templates", "templates directory based on provider-dir")
 	fs.StringVar(&cmd.tfVersion, "tf-version", "", "terraform binary version to download. If not provided, will look for a terraform binary in the local environment. If not found in the environment, will download the latest version of Terraform")
 	fs.BoolVar(&cmd.flagIgnoreDeprecated, "ignore-deprecated", false, "don't generate documentation for deprecated resources and data-sources")
+	fs.BoolVar(&cmd.flagUseProviderPrefix, "use-provider-prefix", false, "include the provider name as a prefix in the filenames of all resource and data-source documents")
 	return fs
 }
 
@@ -109,6 +111,7 @@ func (cmd *generateCmd) runInternal() error {
 		cmd.flagWebsiteSourceDir,
 		cmd.tfVersion,
 		cmd.flagIgnoreDeprecated,
+		cmd.flagUseProviderPrefix,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to generate website: %w", err)


### PR DESCRIPTION
This PR introduces a `--use-provider-prefix` flag for the `tfplugindocs generate` command.  The flag defaults to false, in which case the command behavior around file names matches existing behavior.  When the provider prefix is enabled with `tfplugindocs generate --use-provider-prefix`, resource and data source file names include the `<providerShortName>_` prefix.

The conventional paths documentation is updated to cover default behavior and behavior with the `--use-provider-prefix` flag.  Tests haven't been updated yet.

Closes #347 