### PR TITLE
Update test CI workflow to run on external PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,16 @@
 name: test
 
 on:
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
   push:
-
+    branches: [ main ]
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Possibly due to a quirk with [approving Github action workflow runs from external forks](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks), the test workflow currently doesn't run on external PRs after approval but the workflow runs normally on PRs opened from local branches. Adding the `pull_request` key should fix this.