### PR TITLE
Add `plainmarkdown` breaking change entry to `v0.19.0` changelog

### DIFF
--- a/.changes/0.19.0.md
+++ b/.changes/0.19.0.md
@@ -2,6 +2,7 @@
 
 BREAKING CHANGES:
 
+* generate: the `plainmarkdown` function now removes all markdown elements/formatting to render the output as plain text ([#332](https://github.com/hashicorp/terraform-plugin-docs/issues/332))
 * schemamd: The `schemamd` package has moved to `internal/schemamd` and can no longer be imported ([#354](https://github.com/hashicorp/terraform-plugin-docs/issues/354))
 * functionmd: The `functionmd` package has moved to `internal/functionmd` and can no longer be imported ([#354](https://github.com/hashicorp/terraform-plugin-docs/issues/354))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BREAKING CHANGES:
 
+* generate: the `plainmarkdown` function now removes all markdown elements/formatting to render the output as plain text ([#332](https://github.com/hashicorp/terraform-plugin-docs/issues/332))
 * schemamd: The `schemamd` package has moved to `internal/schemamd` and can no longer be imported ([#354](https://github.com/hashicorp/terraform-plugin-docs/issues/354))
 * functionmd: The `functionmd` package has moved to `internal/functionmd` and can no longer be imported ([#354](https://github.com/hashicorp/terraform-plugin-docs/issues/354))
 


### PR DESCRIPTION
Closes: #355 

PR #332 refactored the `mdplain` package and reimplemented the `plainmarkdown` function using the `yuin/goldmark` library. The purpose of the `plainmarkdown` function is to strip out markdown elements to render the input as plain text, primarily for the YAML frontmatter. The previous implementation of `plainmarkdown` still kept some markdown formatting elements such as links and bulletpoints but removed others like headers. The new implementation in PR #332 now strips out all markdown formatting elements but a changelog entry associated with this change was not included in the `v0.19.0` release. 

This PR retroactively adds a changelog entry into the Changie `0.19.0.md` changelog file and `CHANGELOG.md`