### PR TITLE
Correctly handle `*ast.AutoLink` nodes in the `plainmarkdown` function

### DIFF
--- a/internal/mdplain/renderer.go
+++ b/internal/mdplain/renderer.go
@@ -61,9 +61,12 @@ func (r *TextRender) Render(w io.Writer, source []byte, n ast.Node) error {
 				return ast.WalkSkipChildren, nil
 			}
 			return ast.WalkContinue, nil
-		case *ast.AutoLink, *extAST.Strikethrough:
+		case *extAST.Strikethrough:
 			out.Write(node.Text(source))
 			return ast.WalkContinue, nil
+		case *ast.AutoLink:
+			out.Write(node.URL(source))
+			return ast.WalkSkipChildren, nil
 		case *ast.CodeSpan:
 			out.Write(node.Text(source))
 			return ast.WalkSkipChildren, nil

--- a/internal/mdplain/testdata/markdown.md
+++ b/internal/mdplain/testdata/markdown.md
@@ -50,6 +50,7 @@ These are the elements outlined in John Gruber’s original design document. All
 
 [Relative Link](#Code)
 
+Plain URL: https://www.markdownguide.org
 
 ### Image
 

--- a/internal/mdplain/testdata/mdplain.txt
+++ b/internal/mdplain/testdata/mdplain.txt
@@ -23,6 +23,7 @@ Horizontal Rule
 Link
 Markdown Guide https://www.markdownguide.org
 Relative Link
+Plain URL: https://www.markdownguide.org
 Image
 
 Extended Syntax


### PR DESCRIPTION
Closes: #360 

Fixes a bug where plain URLs (ie `https://github.com/`) were missing from the `plainmarkdown` function output. The `goldmark` library treats links (ie `[link](http://github.com/)`) as a different node type from plain URLs. The previous code for handling the `*ast.AutoLink` node type for plain URLs would output the `Text()` method for the node instead of the `URL()` method. This PR calls the correct method and adds a corresponding unit test case.