### PR TITLE
validate: Default provider name to base directory when running `validate`

### DIFF
--- a/internal/provider/validate.go
+++ b/internal/provider/validate.go
@@ -139,6 +139,10 @@ func (v *validator) validate(ctx context.Context) error {
 
 	var err error
 
+	if v.providerName == "" {
+		v.providerName = filepath.Base(v.providerDir)
+	}
+
 	if v.providersSchemaPath == "" {
 		v.logger.infof("exporting schema from Terraform")
 		v.providerSchema, err = TerraformProviderSchemaFromTerraform(ctx, v.providerName, v.providerDir, v.tfVersion, v.logger)


### PR DESCRIPTION
Closes #376 

Prior to fix, running from root of `terraform-provider-time`:
```bash
 $ tfplugindocs validate                     
exporting schema from Terraform
compiling provider ""
using Terraform CLI binary from PATH if available, otherwise downloading latest Terraform CLI binary
running terraform init
Error executing command: validation errors found: 
error exporting provider schema from Terraform: unable to run terraform init on provider: exit status 1
Terraform encountered problems during initialisation, including problems
with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Invalid provider local name

  on provider.tf line 2:
   2: provider "" {

 is an invalid provider local name: must have at least one character


Error: Invalid provider local name

  on provider.tf line 2:
   2: provider "" {

 is an invalid provider local name: must have at least one character
``` 

After fix:
```bash
 $ tfplugindocs validate
exporting schema from Terraform
compiling provider "time"
using Terraform CLI binary from PATH if available, otherwise downloading latest Terraform CLI binary
running terraform init
getting provider schema
2024/05/24 12:25:25 [DEBUG] Found documentation files [docs/functions/rfc3339_parse.md docs/index.md docs/resources/offset.md docs/resources/rotating.md docs/resources/sleep.md docs/resources/static.md]
running mixed directories check
2024/05/24 12:25:25 [DEBUG] Found directory: docs/functions
2024/05/24 12:25:25 [DEBUG] Found directory: docs
2024/05/24 12:25:25 [DEBUG] Found directory: docs/resources
2024/05/24 12:25:25 [DEBUG] Found directory: docs/resources
2024/05/24 12:25:25 [DEBUG] Found directory: docs/resources
2024/05/24 12:25:25 [DEBUG] Found directory: docs/resources
running number of files check
2024/05/24 12:25:25 [TRACE] Found 1 documentation files in directory: docs/functions
2024/05/24 12:25:25 [TRACE] Found 4 documentation files in directory: docs/resources
2024/05/24 12:25:25 [DEBUG] Found 5 documentation files with limit of 2000
detected static docs directory, running checks
running invalid directories check on docs/functions
running file checks on docs/functions/rfc3339_parse.md
2024/05/24 12:25:25 [DEBUG] Checking file: /Users/austin.valle/code/terraform-provider-time/docs/functions/rfc3339_parse.md
2024/05/24 12:25:25 [DEBUG] File /Users/austin.valle/code/terraform-provider-time/docs/functions/rfc3339_parse.md size: 2061 (limit: 500000)
running file checks on docs/index.md
2024/05/24 12:25:25 [DEBUG] Checking file: /Users/austin.valle/code/terraform-provider-time/docs/index.md
2024/05/24 12:25:25 [DEBUG] File /Users/austin.valle/code/terraform-provider-time/docs/index.md size: 1725 (limit: 500000)
running invalid directories check on docs/resources
running file checks on docs/resources/offset.md
2024/05/24 12:25:25 [DEBUG] Checking file: /Users/austin.valle/code/terraform-provider-time/docs/resources/offset.md
2024/05/24 12:25:25 [DEBUG] File /Users/austin.valle/code/terraform-provider-time/docs/resources/offset.md size: 4082 (limit: 500000)
running file checks on docs/resources/rotating.md
2024/05/24 12:25:25 [DEBUG] Checking file: /Users/austin.valle/code/terraform-provider-time/docs/resources/rotating.md
2024/05/24 12:25:25 [DEBUG] File /Users/austin.valle/code/terraform-provider-time/docs/resources/rotating.md size: 4952 (limit: 500000)
running file checks on docs/resources/sleep.md
2024/05/24 12:25:25 [DEBUG] Checking file: /Users/austin.valle/code/terraform-provider-time/docs/resources/sleep.md
2024/05/24 12:25:25 [DEBUG] File /Users/austin.valle/code/terraform-provider-time/docs/resources/sleep.md size: 4187 (limit: 500000)
running file checks on docs/resources/static.md
2024/05/24 12:25:25 [DEBUG] Checking file: /Users/austin.valle/code/terraform-provider-time/docs/resources/static.md
2024/05/24 12:25:25 [DEBUG] File /Users/austin.valle/code/terraform-provider-time/docs/resources/static.md size: 2713 (limit: 500000)
running file mismatch check
2024/05/24 12:25:25 [DEBUG] Found file offset.md
2024/05/24 12:25:25 [DEBUG] Found file rotating.md
2024/05/24 12:25:25 [DEBUG] Found file sleep.md
2024/05/24 12:25:25 [DEBUG] Found file static.md
2024/05/24 12:25:25 [DEBUG] Found resource time_offset
2024/05/24 12:25:25 [DEBUG] Found resource time_rotating
2024/05/24 12:25:25 [DEBUG] Found resource time_sleep
2024/05/24 12:25:25 [DEBUG] Found resource time_static
```