### PR TITLE
validate: Remove number of files check

### DIFF
--- a/.changes/unreleased/NOTES-20240531-093539.yaml
+++ b/.changes/unreleased/NOTES-20240531-093539.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: 'validate: The number of files check has been removed to match the latest Terraform Registry ingress logic'
+time: 2024-05-31T09:35:39.965379-07:00
+custom:
+    Issue: "9999"

--- a/.changes/unreleased/NOTES-20240531-093539.yaml
+++ b/.changes/unreleased/NOTES-20240531-093539.yaml
@@ -2,4 +2,4 @@ kind: NOTES
 body: 'validate: The number of files check has been removed to match the latest Terraform Registry ingress logic'
 time: 2024-05-31T09:35:39.965379-07:00
 custom:
-    Issue: "9999"
+    Issue: "381"

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ The `validate` subcommand can be used to validate the provider website documenta
 |---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `InvalidDirectoriesCheck` | Checks for valid subdirectory structure and throws an error if an invalid Terraform Provider documentation subdirectory is found.                                                   |
 | `MixedDirectoriesCheck`   | Throws an error if both legacy documentation (`/website/docs`) and registry documentation (`/docs`) are found.                                                                      |
-| `NumberOfFilesCheck`      | Throws an error if the number of files in a directory is larger than the registry limit.                                                                                            |
 | `FileSizeCheck`           | Throws an error if the documentation file is above the registry storage limit.                                                                                                      |
 | `FileExtensionCheck`      | Throws an error if the extension of the given file is not a valid registry documentation extension.                                                                                 |
 | `FrontMatterCheck`        | Checks the YAML frontmatter of documentation for missing required fields or invalid fields.                                                                                         |

--- a/cmd/tfplugindocs/testdata/scripts/schema-json/validate/framework_provider_success_legacy_docs.txtar
+++ b/cmd/tfplugindocs/testdata/scripts/schema-json/validate/framework_provider_success_legacy_docs.txtar
@@ -10,7 +10,6 @@ cmp stdout expected-output.txt
 exporting schema from JSON file
 getting provider schema
 running mixed directories check
-running number of files check
 detected legacy website directory, running checks
 running invalid directories check on website/docs/d
 running file checks on website/docs/d/example.html.md

--- a/cmd/tfplugindocs/testdata/scripts/schema-json/validate/framework_provider_success_registry_docs.txtar
+++ b/cmd/tfplugindocs/testdata/scripts/schema-json/validate/framework_provider_success_registry_docs.txtar
@@ -10,7 +10,6 @@ cmpenv stdout expected-output.txt
 exporting schema from JSON file
 getting provider schema
 running mixed directories check
-running number of files check
 detected static docs directory, running checks
 running invalid directories check on docs/data-sources
 running file checks on docs/data-sources/example.md

--- a/internal/check/directory.go
+++ b/internal/check/directory.go
@@ -118,42 +118,6 @@ func MixedDirectoriesCheck(docFiles []string) error {
 	return nil
 }
 
-// NumberOfFilesCheck verifies that documentation is below the Terraform Registry storage limit.
-// This check presumes that all provided directories are valid, e.g. that directory checking
-// for invalid or mixed directory structures was previously completed.
-func NumberOfFilesCheck(docFiles []string) error {
-	var numberOfFiles int
-
-	directoryCounts := make(map[string]int)
-	for _, file := range docFiles {
-		directory := filepath.Dir(file)
-
-		// Ignore CDKTF files. The file limit is per-language and presumably there is one CDKTF file per source HCL file.
-		if IsValidCdktfDirectory(directory) {
-			continue
-		}
-
-		if directory == RegistryIndexDirectory || directory == filepath.FromSlash(LegacyIndexDirectory) {
-			continue
-		}
-
-		directoryCounts[directory]++
-	}
-
-	for directory, count := range directoryCounts {
-
-		log.Printf("[TRACE] Found %d documentation files in directory: %s", count, directory)
-		numberOfFiles = numberOfFiles + count
-	}
-
-	log.Printf("[DEBUG] Found %d documentation files with limit of %d", numberOfFiles, RegistryMaximumNumberOfFiles)
-	if numberOfFiles >= RegistryMaximumNumberOfFiles {
-		return fmt.Errorf("exceeded maximum (%d) number of documentation files for Terraform Registry: %d", RegistryMaximumNumberOfFiles, numberOfFiles)
-	}
-
-	return nil
-}
-
 func IsValidLegacyDirectory(directory string) bool {
 	for _, validLegacyDirectory := range ValidLegacyDirectories {
 		if directory == filepath.FromSlash(validLegacyDirectory) {

--- a/internal/check/directory_test.go
+++ b/internal/check/directory_test.go
@@ -4,7 +4,6 @@
 package check
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,43 +12,6 @@ import (
 )
 
 var DocumentationGlobPattern = `{docs/index.md,docs/{,cdktf/}{data-sources,guides,resources,functions}/**/*,website/docs/**/*}`
-
-func TestNumberOfFilesCheck(t *testing.T) {
-	t.Parallel()
-	testCases := map[string]struct {
-		files       []string
-		ExpectError bool
-	}{
-		"under limit": {
-			files: testGenerateFiles(RegistryMaximumNumberOfFiles - 1),
-		},
-		"at limit": {
-			files:       testGenerateFiles(RegistryMaximumNumberOfFiles),
-			ExpectError: true,
-		},
-		"over limit": {
-			files:       testGenerateFiles(RegistryMaximumNumberOfFiles + 1),
-			ExpectError: true,
-		},
-	}
-
-	for name, testCase := range testCases {
-		name := name
-		testCase := testCase
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			got := NumberOfFilesCheck(testCase.files)
-
-			if got == nil && testCase.ExpectError {
-				t.Errorf("expected error, got no error")
-			}
-
-			if got != nil && !testCase.ExpectError {
-				t.Errorf("expected no error, got error: %s", got)
-			}
-		})
-	}
-}
 
 func TestMixedDirectoriesCheck(t *testing.T) {
 	t.Parallel()
@@ -90,14 +52,4 @@ func TestMixedDirectoriesCheck(t *testing.T) {
 			}
 		})
 	}
-}
-
-func testGenerateFiles(numberOfFiles int) []string {
-	files := make([]string, numberOfFiles)
-
-	for i := 0; i < numberOfFiles; i++ {
-		files[i] = fmt.Sprintf("thing%d.md", i)
-	}
-
-	return files
 }

--- a/internal/provider/validate.go
+++ b/internal/provider/validate.go
@@ -170,10 +170,6 @@ func (v *validator) validate(ctx context.Context) error {
 	err = check.MixedDirectoriesCheck(files)
 	result = errors.Join(result, err)
 
-	v.logger.infof("running number of files check")
-	err = check.NumberOfFilesCheck(files)
-	result = errors.Join(result, err)
-
 	if dirExists(filepath.Join(v.providerDir, "docs")) {
 		v.logger.infof("detected static docs directory, running checks")
 		err = v.validateStaticDocs(filepath.Join(v.providerDir, "docs"))


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-registry/pull/3811

This check is no longer valid due to a change in the Terraform Registry.