### PR TITLE
all: Bump minimum Go module version to 1.22

### DIFF
--- a/.changes/unreleased/NOTES-20240909-102809.yaml
+++ b/.changes/unreleased/NOTES-20240909-102809.yaml
@@ -1,0 +1,7 @@
+kind: NOTES
+body: 'all: This Go module has been updated to Go 1.22 per the [Go support policy](https://go.dev/doc/devel/release#policy).
+  It is recommended to review the [Go 1.22 release notes](https://go.dev/doc/go1.22)
+  before upgrading. Any consumers building on earlier Go versions may experience errors.'
+time: 2024-09-09T10:28:09.020608-04:00
+custom:
+  Issue: "400"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-plugin-docs
 
-go 1.21
+go 1.22.7
 
 require (
 	github.com/Kunde21/markdownfmt/v3 v3.1.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.21
+go 1.22.7
 
 require github.com/hashicorp/copywrite v0.19.0
 


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/182

Bumps the minimum Go module to 1.22.7