### PR TITLE
Dependabot: Single weekly PR for GH Actions, Single PR for terraform-plugin-* Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,6 @@ updates:
     schedule:
       # Check for updates to Go modules every weekday
       interval: "daily"
-    groups:
-      # Group all terraform-plugin-(go|sdk|framework|testing) dependencies together
-      "terraform-plugin":
-        patterns:
-          - "github.com/hashicorp/terraform-plugin-*"
   # Maintain dependencies for Go modules (tools)
   - package-ecosystem: "gomod"
     directory: "/tools"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@ updates:
     schedule:
       # Check for updates to Go modules every weekday
       interval: "daily"
-
+    groups:
+      # Group all terraform-plugin-(go|sdk|framework|testing) dependencies together
+      "terraform-plugin":
+        patterns:
+          - "github.com/hashicorp/terraform-plugin-*"
   # Maintain dependencies for Go modules (tools)
   - package-ecosystem: "gomod"
     directory: "/tools"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,12 @@ updates:
       interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      "github-actions":
+        patterns:
+          - "*" # Group all GitHub Actions dependencies together
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"


### PR DESCRIPTION

This PR changes the interval for GH Actions updates to a single weekly PR on Mondays at 9am UTC. It also groups all GH Actions updates into a single PR to make it easier for us to review and merge changes across the 30+ repositories we maintain.

Furthermore, this PR starts grouping all terraform-plugin-* Go dependency updates into a single PR as we usually release them (`terraform-plugin-(go|sdk|framework|testing)`) together.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>