### PR TITLE
generate: Add 

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ For examples:
 | `examples/functions/<function name>/function.tf`                          | Function example config           |
 | `examples/resources/<resource name>/resource.tf`                          | Resource example config           |
 | `examples/resources/<resource name>/import.sh`                            | Resource example import command   |
+| `examples/resources/<resource name>/import.tf`                            | Resource example import config    |
 
 #### Migration
 
@@ -280,31 +281,33 @@ using the following data fields and functions:
 
 ##### Provider Fields
 
-|                   Field |  Type  | Description                                                                               |
-|------------------------:|:------:|-------------------------------------------------------------------------------------------|
-|          `.Description` | string | Provider description                                                                      |
-|           `.HasExample` |  bool  | Is there an example file?                                                                 |
-|          `.ExampleFile` | string | Path to the file with the terraform configuration example                                 |
-|         `.ProviderName` | string | Canonical provider name (ex. `terraform-provider-random`)                                 |
-|    `.ProviderShortName` | string | Short version of the rendered provider name (ex. `random`)                                |
+| Field                   | Type   | Description                                                                               |
+|-------------------------|--------|-------------------------------------------------------------------------------------------|
+| `.Description`          | string | Provider description                                                                      |
+| `.HasExample`           | bool   | Is there an example file?                                                                 |
+| `.ExampleFile`          | string | Path to the file with the terraform configuration example                                 |
+| `.ProviderName`         | string | Canonical provider name (ex. `terraform-provider-random`)                                 |
+| `.ProviderShortName`    | string | Short version of the rendered provider name (ex. `random`)                                |
 | `.RenderedProviderName` | string | Value provided via argument `--rendered-provider-name`, otherwise same as `.ProviderName` |
-|       `.SchemaMarkdown` | string | a Markdown formatted Provider Schema definition                                           |
+| `.SchemaMarkdown`       | string | a Markdown formatted Provider Schema definition                                           |
 
 ##### Managed Resource / Ephemeral Resource / Data Source Fields
 
-|                   Field |  Type  | Description                                                                               |
-|------------------------:|:------:|-------------------------------------------------------------------------------------------|
-|                 `.Name` | string | Name of the resource/data-source (ex. `tls_certificate`)                                  |
-|                 `.Type` | string | Either `Resource` or `Data Source`                                                        |
-|          `.Description` | string | Resource / Data Source description                                                        |
-|           `.HasExample` |  bool  | Is there an example file?                                                                 |
-|          `.ExampleFile` | string | Path to the file with the terraform configuration example                                 |
-|            `.HasImport` |  bool  | Is there an import file?                                                                  |
-|           `.ImportFile` | string | Path to the file with the command for importing the resource                              |
-|         `.ProviderName` | string | Canonical provider name (ex. `terraform-provider-random`)                                 |
-|    `.ProviderShortName` | string | Short version of the rendered provider name (ex. `random`)                                |
+| Field                   | Type   | Description                                                                               |
+|-------------------------|--------|-------------------------------------------------------------------------------------------|
+| `.Name`                 | string | Name of the resource/data-source (ex. `tls_certificate`)                                  |
+| `.Type`                 | string | Either `Resource` or `Data Source`                                                        |
+| `.Description`          | string | Resource / Data Source description                                                        |
+| `.HasExample`           | bool   | Is there an example file?                                                                 |
+| `.ExampleFile`          | string | Path to the file with the terraform configuration example                                 |
+| `.HasImport`            | bool   | Is there an import shell file? (`terraform import` shell example)                         |
+| `.ImportFile`           | string | Path to the file with the command for importing the resource                              |
+| `.HasImportConfig`      | bool   | Is there an import terraform config file? (`import` block example)                        |
+| `.ImportConfigFile`     | string | Path to the file with the Terraform configuration for importing the resource              |
+| `.ProviderName`         | string | Canonical provider name (ex. `terraform-provider-random`)                                 |
+| `.ProviderShortName`    | string | Short version of the rendered provider name (ex. `random`)                                |
 | `.RenderedProviderName` | string | Value provided via argument `--rendered-provider-name`, otherwise same as `.ProviderName` |
-|       `.SchemaMarkdown` | string | a Markdown formatted Resource / Data Source Schema definition                             |
+| `.SchemaMarkdown`       | string | a Markdown formatted Resource / Data Source Schema definition                             |
 
 ##### Provider-defined Function Fields
 

--- a/README.md
+++ b/README.md
@@ -223,16 +223,16 @@ For examples:
 > **NOTE:** In the following conventional paths for examples, `<data source name>` and `<resource name>` include the provider prefix as well, but the provider prefix is **NOT** included in`<function name>`.
 > For example, the data source [`caller_identity`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) in the `aws` provider would have an "example" conventional path of: `examples/data-sources/aws_caller_identity/data-source.tf`
 
-| Path                                                                      | Description                       |
-|---------------------------------------------------------------------------|-----------------------------------|
-| `examples/`                                                               | Root of examples                  |
-| `examples/provider/provider.tf`                                           | Provider example config           |
-| `examples/data-sources/<data source name>/data-source.tf`                 | Data source example config        |
-| `examples/ephemeral-resources/<ephemeral resource>/ephemeral-resource.tf` | Ephemeral resource example config |
-| `examples/functions/<function name>/function.tf`                          | Function example config           |
-| `examples/resources/<resource name>/resource.tf`                          | Resource example config           |
-| `examples/resources/<resource name>/import.sh`                            | Resource example import command   |
-| `examples/resources/<resource name>/import.tf`                            | Resource example import config    |
+| Path                                                                      | Description                          |
+|---------------------------------------------------------------------------|--------------------------------------|
+| `examples/`                                                               | Root of examples                     |
+| `examples/provider/provider.tf`                                           | Provider example config              |
+| `examples/data-sources/<data source name>/data-source.tf`                 | Data source example config           |
+| `examples/ephemeral-resources/<ephemeral resource>/ephemeral-resource.tf` | Ephemeral resource example config    |
+| `examples/functions/<function name>/function.tf`                          | Function example config              |
+| `examples/resources/<resource name>/resource.tf`                          | Resource example config              |
+| `examples/resources/<resource name>/import.sh`                            | Resource example import command      |
+| `examples/resources/<resource name>/import-id.tf`                         | Resource example import by id config |
 
 #### Migration
 
@@ -302,8 +302,8 @@ using the following data fields and functions:
 | `.ExampleFile`          | string | Path to the file with the terraform configuration example                                 |
 | `.HasImport`            | bool   | Is there an import shell file? (`terraform import` shell example)                         |
 | `.ImportFile`           | string | Path to the file with the command for importing the resource                              |
-| `.HasImportConfig`      | bool   | Is there an import terraform config file? (`import` block example)                        |
-| `.ImportConfigFile`     | string | Path to the file with the Terraform configuration for importing the resource              |
+| `.HasImportIDConfig`    | bool   | Is there an import terraform config file? (`import` block example with `id`)              |
+| `.ImportIDConfigFile`   | string | Path to the file with the Terraform configuration for importing the resource by `id`      |
 | `.ProviderName`         | string | Canonical provider name (ex. `terraform-provider-random`)                                 |
 | `.ProviderShortName`    | string | Short version of the rendered provider name (ex. `random`)                                |
 | `.RenderedProviderName` | string | Value provided via argument `--rendered-provider-name`, otherwise same as `.ProviderName` |

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -629,7 +629,7 @@ func (g *generator) renderStaticWebsite(providerSchema *tfjson.ProviderSchema) e
 
 			if resSchema != nil {
 				tmpl := resourceTemplate(tmplData)
-				render, err := tmpl.Render(g.providerDir, resName, g.providerName, g.renderedProviderName, "Data Source", exampleFilePath, "", resSchema)
+				render, err := tmpl.Render(g.providerDir, resName, g.providerName, g.renderedProviderName, "Data Source", exampleFilePath, "", "", resSchema)
 				if err != nil {
 					return fmt.Errorf("unable to render data source template %q: %w", rel, err)
 				}
@@ -644,10 +644,11 @@ func (g *generator) renderStaticWebsite(providerSchema *tfjson.ProviderSchema) e
 			resSchema, resName := resourceSchema(providerSchema.ResourceSchemas, shortName, relFile)
 			exampleFilePath := filepath.Join(g.ProviderExamplesDir(), "resources", resName, "resource.tf")
 			importFilePath := filepath.Join(g.ProviderExamplesDir(), "resources", resName, "import.sh")
+			importConfigFilePath := filepath.Join(g.ProviderExamplesDir(), "resources", resName, "import.tf")
 
 			if resSchema != nil {
 				tmpl := resourceTemplate(tmplData)
-				render, err := tmpl.Render(g.providerDir, resName, g.providerName, g.renderedProviderName, "Resource", exampleFilePath, importFilePath, resSchema)
+				render, err := tmpl.Render(g.providerDir, resName, g.providerName, g.renderedProviderName, "Resource", exampleFilePath, importConfigFilePath, importFilePath, resSchema)
 				if err != nil {
 					return fmt.Errorf("unable to render resource template %q: %w", rel, err)
 				}
@@ -682,7 +683,7 @@ func (g *generator) renderStaticWebsite(providerSchema *tfjson.ProviderSchema) e
 
 			if resSchema != nil {
 				tmpl := resourceTemplate(tmplData)
-				render, err := tmpl.Render(g.providerDir, resName, g.providerName, g.renderedProviderName, "Ephemeral Resource", exampleFilePath, "", resSchema)
+				render, err := tmpl.Render(g.providerDir, resName, g.providerName, g.renderedProviderName, "Ephemeral Resource", exampleFilePath, "", "", resSchema)
 				if err != nil {
 					return fmt.Errorf("unable to render ephemeral resource template %q: %w", rel, err)
 				}

--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -644,11 +644,11 @@ func (g *generator) renderStaticWebsite(providerSchema *tfjson.ProviderSchema) e
 			resSchema, resName := resourceSchema(providerSchema.ResourceSchemas, shortName, relFile)
 			exampleFilePath := filepath.Join(g.ProviderExamplesDir(), "resources", resName, "resource.tf")
 			importFilePath := filepath.Join(g.ProviderExamplesDir(), "resources", resName, "import.sh")
-			importConfigFilePath := filepath.Join(g.ProviderExamplesDir(), "resources", resName, "import.tf")
+			importIDConfigFilePath := filepath.Join(g.ProviderExamplesDir(), "resources", resName, "import-id.tf")
 
 			if resSchema != nil {
 				tmpl := resourceTemplate(tmplData)
-				render, err := tmpl.Render(g.providerDir, resName, g.providerName, g.renderedProviderName, "Resource", exampleFilePath, importConfigFilePath, importFilePath, resSchema)
+				render, err := tmpl.Render(g.providerDir, resName, g.providerName, g.renderedProviderName, "Resource", exampleFilePath, importIDConfigFilePath, importFilePath, resSchema)
 				if err != nil {
 					return fmt.Errorf("unable to render resource template %q: %w", rel, err)
 				}

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -158,7 +158,7 @@ func (t providerTemplate) Render(providerDir, providerName, renderedProviderName
 	})
 }
 
-func (t resourceTemplate) Render(providerDir, name, providerName, renderedProviderName, typeName, exampleFile, importConfigFile, importCmdFile string, schema *tfjson.Schema) (string, error) {
+func (t resourceTemplate) Render(providerDir, name, providerName, renderedProviderName, typeName, exampleFile, importIDConfigFile, importCmdFile string, schema *tfjson.Schema) (string, error) {
 	schemaBuffer := bytes.NewBuffer(nil)
 	err := schemamd.Render(schema, schemaBuffer)
 	if err != nil {
@@ -181,8 +181,8 @@ func (t resourceTemplate) Render(providerDir, name, providerName, renderedProvid
 		HasImport  bool
 		ImportFile string
 
-		HasImportConfig  bool
-		ImportConfigFile string
+		HasImportIDConfig  bool
+		ImportIDConfigFile string
 
 		ProviderName      string
 		ProviderShortName string
@@ -201,8 +201,8 @@ func (t resourceTemplate) Render(providerDir, name, providerName, renderedProvid
 		HasImport:  importCmdFile != "" && fileExists(importCmdFile),
 		ImportFile: importCmdFile,
 
-		HasImportConfig:  importConfigFile != "" && fileExists(importConfigFile),
-		ImportConfigFile: importConfigFile,
+		HasImportIDConfig:  importIDConfigFile != "" && fileExists(importIDConfigFile),
+		ImportIDConfigFile: importIDConfigFile,
 
 		ProviderName:      providerName,
 		ProviderShortName: providerShortName(renderedProviderName),
@@ -294,17 +294,17 @@ description: |-
 {{- end }}
 
 {{ .SchemaMarkdown | trimspace }}
-{{- if or .HasImport .HasImportConfig }}
+{{- if or .HasImport .HasImportIDConfig }}
 
 ## Import
 
 Import is supported using the following syntax:
 {{- end }}
-{{- if .HasImportConfig }}
+{{- if .HasImportIDConfig }}
 
 In Terraform v1.5.0 and later, the [` + "`" + `import` + "`" + ` block](https://developer.hashicorp.com/terraform/language/import) can be used, for example:
 
-{{tffile .ImportConfigFile }}
+{{tffile .ImportIDConfigFile }}
 {{- end }}
 {{- if .HasImport }}
 

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -302,7 +302,7 @@ Import is supported using the following syntax:
 {{- end }}
 {{- if .HasImportIDConfig }}
 
-In Terraform v1.5.0 and later, the [` + "`" + `import` + "`" + ` block](https://developer.hashicorp.com/terraform/language/import) can be used, for example:
+In Terraform v1.5.0 and later, the [` + "`" + `import` + "`" + ` block](https://developer.hashicorp.com/terraform/language/import) can be used with the ` + "`" + `id` + "`" + ` attribute, for example:
 
 {{tffile .ImportIDConfigFile }}
 {{- end }}

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -158,7 +158,7 @@ func (t providerTemplate) Render(providerDir, providerName, renderedProviderName
 	})
 }
 
-func (t resourceTemplate) Render(providerDir, name, providerName, renderedProviderName, typeName, exampleFile, importFile string, schema *tfjson.Schema) (string, error) {
+func (t resourceTemplate) Render(providerDir, name, providerName, renderedProviderName, typeName, exampleFile, importConfigFile, importCmdFile string, schema *tfjson.Schema) (string, error) {
 	schemaBuffer := bytes.NewBuffer(nil)
 	err := schemamd.Render(schema, schemaBuffer)
 	if err != nil {
@@ -181,6 +181,9 @@ func (t resourceTemplate) Render(providerDir, name, providerName, renderedProvid
 		HasImport  bool
 		ImportFile string
 
+		HasImportConfig  bool
+		ImportConfigFile string
+
 		ProviderName      string
 		ProviderShortName string
 
@@ -195,8 +198,11 @@ func (t resourceTemplate) Render(providerDir, name, providerName, renderedProvid
 		HasExample:  exampleFile != "" && fileExists(exampleFile),
 		ExampleFile: exampleFile,
 
-		HasImport:  importFile != "" && fileExists(importFile),
-		ImportFile: importFile,
+		HasImport:  importCmdFile != "" && fileExists(importCmdFile),
+		ImportFile: importCmdFile,
+
+		HasImportConfig:  importConfigFile != "" && fileExists(importConfigFile),
+		ImportConfigFile: importConfigFile,
 
 		ProviderName:      providerName,
 		ProviderShortName: providerShortName(renderedProviderName),
@@ -288,11 +294,21 @@ description: |-
 {{- end }}
 
 {{ .SchemaMarkdown | trimspace }}
-{{- if .HasImport }}
+{{- if or .HasImport .HasImportConfig }}
 
 ## Import
 
 Import is supported using the following syntax:
+{{- end }}
+{{- if .HasImportConfig }}
+
+In Terraform v1.5.0 and later, the [` + "`" + `import` + "`" + ` block](https://developer.hashicorp.com/terraform/language/import) can be used, for example:
+
+{{tffile .ImportConfigFile }}
+{{- end }}
+{{- if .HasImport }}
+
+The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 {{codefile "shell" .ImportFile }}
 {{- end }}

--- a/internal/provider/template_test.go
+++ b/internal/provider/template_test.go
@@ -93,7 +93,7 @@ provider "scaffolding" {
 		},
 	}
 
-	result, err := tpl.Render("testdata/test-provider-dir", "testTemplate", "test-provider", "test-provider", "Resource", "provider.tf", "provider.tf", &schema)
+	result, err := tpl.Render("testdata/test-provider-dir", "testTemplate", "test-provider", "test-provider", "Resource", "provider.tf", "", "", &schema)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
> Currently a WIP, needs some actual e2e tests 😄 

## Related Issue

Closes #472 

## Description

This PR adds support for defining an example import TF configuration file in the same location as the existing `import.sh` file:
- `examples/resources/<resource name>/import-id.tf`

I'm intentionally choosing the `id` suffix following import because identity should probably be it's own config file (`import-identity.tf` for example). Since it has a different TF version requirement and can live next to the other import methods.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
