### PR TITLE
mdplain: Render all text node children of link nodes

### DIFF
--- a/internal/mdplain/testdata/markdown.md
+++ b/internal/mdplain/testdata/markdown.md
@@ -52,6 +52,8 @@ These are the elements outlined in John Gruber’s original design document. All
 
 Plain URL: https://www.markdownguide.org
 
+[`Code Link`](https://www.markdownguide.org)
+
 ### Image
 
 ![alt text](https://www.markdownguide.org/assets/images/tux.png)

--- a/internal/mdplain/testdata/mdplain.txt
+++ b/internal/mdplain/testdata/mdplain.txt
@@ -24,6 +24,7 @@ Link
 Markdown Guide https://www.markdownguide.org
 Relative Link
 Plain URL: https://www.markdownguide.org
+Code Link https://www.markdownguide.org
 Image
 
 Extended Syntax


### PR DESCRIPTION
## Description

In #484, the markdown rendering logic in `mdplain` package was refactored due to the deprecation of the `(*BaseNode).Text()` method in the `yuin/goldmark` library. When handling link nodes, the logic in the previous PR assumed that the text node would always be the first child of the link node. However, there are many cases where the text node is not the first child of a link node or is nested within another node, like when a code span is combined with a link:

```md
[`link text`](http://example.com)
```

in the above example, the first child of the link node is the code span node and it's child is the text node containing the `link text` value. 

This PR introduces a `renderText()` helper method that recursively walks all of the input node's children and writes the value of any encountered text nodes to the buffer.

Note: this does not need a changelog as the changes in #484 have not been released yet.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No.