### PR TITLE
Revert "Bump github.com/yuin/goldmark from 1.7.7 to 1.7.12 (#484)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/terraform-json v0.25.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/rogpeppe/go-internal v1.14.1
-	github.com/yuin/goldmark v1.7.12
+	github.com/yuin/goldmark v1.7.7
 	github.com/yuin/goldmark-meta v1.1.0
 	github.com/zclconf/go-cty v1.16.3
 	go.abhg.dev/goldmark/frontmatter v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuin/goldmark v1.7.12 h1:YwGP/rrea2/CnCtUHgjuolG/PnMxdQtPMO5PvaE2/nY=
-github.com/yuin/goldmark v1.7.12/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.7.7 h1:5m9rrB1sW3JUMToKFQfb+FGt1U7r57IHu5GrYrG2nqU=
+github.com/yuin/goldmark v1.7.7/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 github.com/yuin/goldmark-meta v1.1.0 h1:pWw+JLHGZe8Rk0EGsMVssiNb/AaPMHfSRszZeUeiOUc=
 github.com/yuin/goldmark-meta v1.1.0/go.mod h1:U4spWENafuA7Zyg+Lj5RqK/MF+ovMYtBvXi1lBb2VP0=
 github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk=

--- a/internal/mdplain/renderer.go
+++ b/internal/mdplain/renderer.go
@@ -26,51 +26,59 @@ func (r *TextRender) Render(w io.Writer, source []byte, n ast.Node) error {
 		}
 
 		switch node := node.(type) {
-		case *ast.Blockquote, *ast.CodeSpan:
-			return ast.WalkContinue, nil
-		case *ast.Heading, *ast.CodeBlock, *ast.List:
+		case *ast.Blockquote, *ast.Heading:
 			doubleSpace(out)
-			return ast.WalkContinue, nil
+			out.Write(node.Text(source))
+			return ast.WalkSkipChildren, nil
 		case *ast.ThematicBreak:
 			doubleSpace(out)
+			return ast.WalkSkipChildren, nil
+		case *ast.CodeBlock:
+			doubleSpace(out)
+			for i := 0; i < node.Lines().Len(); i++ {
+				line := node.Lines().At(i)
+				out.Write(line.Value(source))
+			}
 			return ast.WalkSkipChildren, nil
 		case *ast.FencedCodeBlock:
 			doubleSpace(out)
 			doubleSpace(out)
-			out.Write(node.Lines().Value(source))
+			for i := 0; i < node.Lines().Len(); i++ {
+				line := node.Lines().At(i)
+				_, _ = out.Write(line.Value(source))
+			}
+			return ast.WalkSkipChildren, nil
+		case *ast.List:
+			doubleSpace(out)
 			return ast.WalkContinue, nil
 		case *ast.Paragraph:
 			doubleSpace(out)
-			if node.Lines().Value(source)[0] == '|' { // Write tables as-is.
-				out.Write(node.Lines().Value(source))
+			if node.Text(source)[0] == '|' { // Write tables as-is.
+				for i := 0; i < node.Lines().Len(); i++ {
+					line := node.Lines().At(i)
+					out.Write(line.Value(source))
+				}
 				return ast.WalkSkipChildren, nil
 			}
 			return ast.WalkContinue, nil
 		case *extAST.Strikethrough:
-			out.Write(node.Lines().Value(source))
+			out.Write(node.Text(source))
 			return ast.WalkContinue, nil
 		case *ast.AutoLink:
 			out.Write(node.URL(source))
 			return ast.WalkSkipChildren, nil
+		case *ast.CodeSpan:
+			out.Write(node.Text(source))
+			return ast.WalkSkipChildren, nil
 		case *ast.Link:
-			// we want to write the text of the
-			// link before the url
-			child := node.FirstChild()
-			if child != nil {
-				t, ok := child.(*ast.Text)
-				if ok {
-					out.Write(t.Value(source))
-				}
-			}
-
+			_, err := out.Write(node.Text(source))
 			if !isRelativeLink(node.Destination) {
 				out.WriteString(" ")
 				out.Write(node.Destination)
 			}
-
-			return ast.WalkSkipChildren, nil
+			return ast.WalkSkipChildren, err
 		case *ast.Text:
-			out.Write(node.Value(source))
+			out.Write(node.Text(source))
 			if node.SoftLineBreak() {
 				doubleSpace(out)
 			}

--- a/internal/provider/migrate.go
+++ b/internal/provider/migrate.go
@@ -296,7 +296,7 @@ func (m *migrator) ExtractCodeExamples(content []byte, newRelDir string, templat
 		if fencedNode, isFenced := node.(*ast.FencedCodeBlock); isFenced && fencedNode.Info != nil {
 			var ext, exampleName, examplePath, template string
 
-			lang := string(fencedNode.Info.Value(content)[:])
+			lang := string(fencedNode.Info.Text(content)[:])
 			switch lang {
 			case "hcl", "terraform":
 				exampleCount++


### PR DESCRIPTION
This reverts commit 8b2645d33ebb685b19030284154b5c7c1510fedf (PR #484)

## Description

In #484, the markdown rendering logic in `mdplain `package was refactored due to the deprecation of the `(*BaseNode).Text()` method in the `yuin/goldmark` library. The approach in that PR didn't cover all edge cases scenarios, as demonstrated by #497, so we are reverting that PR for now to unblock the upcoming `v0.22.0` release


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No