### PR TITLE
chore: Fix CI to run on public forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,13 @@
 name: test
 
 on:
-  push:
+  pull_request:
+    paths:
+      - .github/workflows/test.yml
+      - .golangci.yml
+      - go.mod
+      - '**.go'
+      - '**.txtar'
 
 jobs:
   test:


### PR DESCRIPTION
## Related Issue

N/A

## Description

The `push` event does not run for public forks, so we should switch to using the `pull_request` target so that we get the "requires approval" dialogue: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull-request-events-for-forked-repositories

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
