### PR TITLE
fix: add support for detecting missing folder in docs/

### DIFF
--- a/internal/check/file_mismatch.go
+++ b/internal/check/file_mismatch.go
@@ -228,13 +228,20 @@ func (check *FileMismatchCheck) FunctionFileMismatchCheck(files []os.DirEntry, f
 
 // ActionFileMismatchCheck checks for mismatched files, either missing or extraneous, against the action schema
 func (check *FileMismatchCheck) ActionFileMismatchCheck(files []os.DirEntry, actionType string, schemas map[string]*tfjson.ActionSchema) error {
-	if len(files) == 0 {
-		log.Printf("[DEBUG] Skipping %s file mismatch checks due to missing file list", actionType)
+	if len(schemas) == 0 {
+		log.Printf("[DEBUG] Skipping %s file mismatch checks due to missing schemas", actionType)
 		return nil
 	}
 
-	if len(schemas) == 0 {
-		log.Printf("[DEBUG] Skipping %s file mismatch checks due to missing schemas", actionType)
+	if len(files) == 0 {
+		// No files found, report all schemas as missing documentation
+		for _, actionName := range actionNames(schemas) {
+			if check.IgnoreFileMissing(actionName) {
+				continue
+			}
+			log.Printf("[DEBUG] Missing file for %s %s", actionType, actionName)
+			return fmt.Errorf("missing documentation file for %s: %s", actionType, actionName)
+		}
 		return nil
 	}
 

--- a/internal/check/file_mismatch.go
+++ b/internal/check/file_mismatch.go
@@ -107,13 +107,20 @@ func (check *FileMismatchCheck) Run() error {
 
 // ResourceFileMismatchCheck checks for mismatched files, either missing or extraneous, against the resource/datasource schema
 func (check *FileMismatchCheck) ResourceFileMismatchCheck(files []os.DirEntry, resourceType string, schemas map[string]*tfjson.Schema) error {
-	if len(files) == 0 {
-		log.Printf("[DEBUG] Skipping %s file mismatch checks due to missing file list", resourceType)
+	if len(schemas) == 0 {
+		log.Printf("[DEBUG] Skipping %s file mismatch checks due to missing schemas", resourceType)
 		return nil
 	}
 
-	if len(schemas) == 0 {
-		log.Printf("[DEBUG] Skipping %s file mismatch checks due to missing schemas", resourceType)
+	if len(files) == 0 {
+		// No files found, report all schemas as missing documentation
+		for _, resourceName := range resourceNames(schemas) {
+			if check.IgnoreFileMissing(resourceName) {
+				continue
+			}
+			log.Printf("[DEBUG] Missing file for %s %s", resourceType, resourceName)
+			return fmt.Errorf("missing documentation file for %s: %s", resourceType, resourceName)
+		}
 		return nil
 	}
 

--- a/internal/check/file_mismatch_test.go
+++ b/internal/check/file_mismatch_test.go
@@ -382,6 +382,15 @@ func TestFileMismatchCheck(t *testing.T) {
 			},
 		},
 		"no files": {
+			ResourceFiles: fstest.MapFS{
+				"resource1.md": {},
+			},
+			FunctionFiles: fstest.MapFS{
+				"function1.md": {},
+			},
+			ActionFiles: fstest.MapFS{
+				"action1.md": {},
+			},
 			Options: &FileMismatchOptions{
 				ProviderShortName: "test",
 				Schema: &tfjson.ProviderSchema{
@@ -399,6 +408,7 @@ func TestFileMismatchCheck(t *testing.T) {
 					},
 				},
 			},
+			ExpectError: true,
 		},
 		"no schemas": {
 			ResourceFiles: fstest.MapFS{

--- a/internal/provider/validate.go
+++ b/internal/provider/validate.go
@@ -317,21 +317,21 @@ func (v *validator) validateStaticDocs() error {
 	if dirExists(v.providerFS, dir+"/actions") {
 		actionFiles, _ := fs.ReadDir(v.providerFS, dir+"/actions")
 		mismatchOpt.ActionEntries = actionFiles
-	} else if len(v.providerSchema.ActionSchemas) > 0 {
+	} else if v.providerSchema != nil && len(v.providerSchema.ActionSchemas) > 0 {
 		// If actions exist in schema but directory doesn't, create empty slice to trigger validation
 		mismatchOpt.ActionEntries = []os.DirEntry{}
 	}
 	if dirExists(v.providerFS, dir+"/list-resources") {
 		listResourceFiles, _ := fs.ReadDir(v.providerFS, dir+"/list-resources")
 		mismatchOpt.ListResourceEntries = listResourceFiles
-	} else if len(v.providerSchema.ListResourceSchemas) > 0 {
+	} else if v.providerSchema != nil && len(v.providerSchema.ListResourceSchemas) > 0 {
 		// If list resources exist in schema but directory doesn't, create empty slice to trigger validation
 		mismatchOpt.ListResourceEntries = []os.DirEntry{}
 	}
 	if dirExists(v.providerFS, dir+"/state-stores") {
 		stateStoreFiles, _ := fs.ReadDir(v.providerFS, dir+"/state-stores")
 		mismatchOpt.StateStoreEntries = stateStoreFiles
-	} else if len(v.providerSchema.StateStoreSchemas) > 0 {
+	} else if v.providerSchema != nil && len(v.providerSchema.StateStoreSchemas) > 0 {
 		// If state stores exist in schema but directory doesn't, create empty slice to trigger validation
 		mismatchOpt.StateStoreEntries = []os.DirEntry{}
 	}
@@ -425,21 +425,21 @@ func (v *validator) validateLegacyWebsite() error {
 	if dirExists(v.providerFS, dir+"/actions") {
 		actionFiles, _ := fs.ReadDir(v.providerFS, dir+"/actions")
 		mismatchOpt.ActionEntries = actionFiles
-	} else if len(v.providerSchema.ActionSchemas) > 0 {
+	} else if v.providerSchema != nil && len(v.providerSchema.ActionSchemas) > 0 {
 		// If actions exist in schema but directory doesn't, create empty slice to trigger validation
 		mismatchOpt.ActionEntries = []os.DirEntry{}
 	}
 	if dirExists(v.providerFS, dir+"/list-resources") {
 		listResourceFiles, _ := fs.ReadDir(v.providerFS, dir+"/list-resources")
 		mismatchOpt.ListResourceEntries = listResourceFiles
-	} else if len(v.providerSchema.ListResourceSchemas) > 0 {
+	} else if v.providerSchema != nil && len(v.providerSchema.ListResourceSchemas) > 0 {
 		// If list resources exist in schema but directory doesn't, create empty slice to trigger validation
 		mismatchOpt.ListResourceEntries = []os.DirEntry{}
 	}
 	if dirExists(v.providerFS, dir+"/state-stores") {
 		stateStoreFiles, _ := fs.ReadDir(v.providerFS, dir+"/state-stores")
 		mismatchOpt.StateStoreEntries = stateStoreFiles
-	} else if len(v.providerSchema.StateStoreSchemas) > 0 {
+	} else if v.providerSchema != nil && len(v.providerSchema.StateStoreSchemas) > 0 {
 		// If state stores exist in schema but directory doesn't, create empty slice to trigger validation
 		mismatchOpt.StateStoreEntries = []os.DirEntry{}
 	}

--- a/internal/provider/validate.go
+++ b/internal/provider/validate.go
@@ -317,14 +317,23 @@ func (v *validator) validateStaticDocs() error {
 	if dirExists(v.providerFS, dir+"/actions") {
 		actionFiles, _ := fs.ReadDir(v.providerFS, dir+"/actions")
 		mismatchOpt.ActionEntries = actionFiles
+	} else if len(v.providerSchema.ActionSchemas) > 0 {
+		// If actions exist in schema but directory doesn't, create empty slice to trigger validation
+		mismatchOpt.ActionEntries = []os.DirEntry{}
 	}
 	if dirExists(v.providerFS, dir+"/list-resources") {
 		listResourceFiles, _ := fs.ReadDir(v.providerFS, dir+"/list-resources")
 		mismatchOpt.ListResourceEntries = listResourceFiles
+	} else if len(v.providerSchema.ListResourceSchemas) > 0 {
+		// If list resources exist in schema but directory doesn't, create empty slice to trigger validation
+		mismatchOpt.ListResourceEntries = []os.DirEntry{}
 	}
 	if dirExists(v.providerFS, dir+"/state-stores") {
 		stateStoreFiles, _ := fs.ReadDir(v.providerFS, dir+"/state-stores")
 		mismatchOpt.StateStoreEntries = stateStoreFiles
+	} else if len(v.providerSchema.StateStoreSchemas) > 0 {
+		// If state stores exist in schema but directory doesn't, create empty slice to trigger validation
+		mismatchOpt.StateStoreEntries = []os.DirEntry{}
 	}
 
 	v.logger.infof("running file mismatch check")
@@ -416,14 +425,23 @@ func (v *validator) validateLegacyWebsite() error {
 	if dirExists(v.providerFS, dir+"/actions") {
 		actionFiles, _ := fs.ReadDir(v.providerFS, dir+"/actions")
 		mismatchOpt.ActionEntries = actionFiles
+	} else if len(v.providerSchema.ActionSchemas) > 0 {
+		// If actions exist in schema but directory doesn't, create empty slice to trigger validation
+		mismatchOpt.ActionEntries = []os.DirEntry{}
 	}
 	if dirExists(v.providerFS, dir+"/list-resources") {
 		listResourceFiles, _ := fs.ReadDir(v.providerFS, dir+"/list-resources")
 		mismatchOpt.ListResourceEntries = listResourceFiles
+	} else if len(v.providerSchema.ListResourceSchemas) > 0 {
+		// If list resources exist in schema but directory doesn't, create empty slice to trigger validation
+		mismatchOpt.ListResourceEntries = []os.DirEntry{}
 	}
 	if dirExists(v.providerFS, dir+"/state-stores") {
 		stateStoreFiles, _ := fs.ReadDir(v.providerFS, dir+"/state-stores")
 		mismatchOpt.StateStoreEntries = stateStoreFiles
+	} else if len(v.providerSchema.StateStoreSchemas) > 0 {
+		// If state stores exist in schema but directory doesn't, create empty slice to trigger validation
+		mismatchOpt.StateStoreEntries = []os.DirEntry{}
 	}
 
 	v.logger.infof("running file mismatch check")


### PR DESCRIPTION
## Related Issue

Fixes #584 

## Description

I forgot the documentation for my new list resource and I was surprised to not having an error when I tried to validate the documentation for it. I think it is because when the folder is just not present, no error is raised.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
