### PR TITLE
chore: add changie entry for hc-install v0.9.4 bump

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260420-160827.yaml
+++ b/.changes/unreleased/BUG FIXES-20260420-160827.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'deps: bump github.com/hashicorp/hc-install to v0.9.4'
+time: 2026-04-20T16:08:27.534959+02:00
+custom:
+    Issue: "589"


### PR DESCRIPTION
## Summary
- add a changie unreleased entry for the merged `hc-install v0.9.4` dependency bump
- link the release note to PR `#589`