### PR TITLE
feat(templates): add prefix and suffix string template functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ using the following data fields and functions:
 | Function        | Example                                          | Description                                                                                       |
 |-----------------|--------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | `codefile`      | `{{codefile "shell" "path/to/file.sh"}}`         | Create a Markdown code block with the content of a file. Path is relative to the repository root. |
+| `hasPrefix`     | `{{if hasPrefix "FOO BAR" "FOO"}}`               | Equivalent to [`strings.HasPrefix`](https://pkg.go.dev/strings#HasPrefix).                            |
+| `hasSuffix`     | `{{if hasSuffix "FOO BAR" "BAR"}}`               | Equivalent to [`strings.HasSuffix`](https://pkg.go.dev/strings#HasSuffix).                            |
 | `lower`         | `{{"EXAMPLE STRING" \| lower}}`                  | Equivalent to [`strings.ToLower`](https://pkg.go.dev/strings#ToLower).                            |
 | `plainmarkdown` | `{{"*example markdown*" \| plainmarkdown }}`     | Render Markdown content as plaintext.                                                             |
 | `prefixlines`   | `{{"example string" \| prefixlines "prefix: "}}` | Add a prefix to all (newline-separated) lines in a string.                                        |

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -112,6 +112,8 @@ func newTemplate(providerDir, name, text string) (*template.Template, error) {
 
 	tmpl.Funcs(map[string]interface{}{
 		"codefile":      codeFile(providerDir),
+		"hasPrefix":     strings.HasPrefix,
+		"hasSuffix":     strings.HasSuffix,
 		"lower":         strings.ToLower,
 		"plainmarkdown": mdplain.PlainMarkdown,
 		"prefixlines":   tmplfuncs.PrefixLines,


### PR DESCRIPTION
## Related Issue

relates to #591

## Description

Registered the default `strings.HasPrefix` and `strings.HasSuffix` string functions for usage in the templates.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
