### PR TITLE
fix: blank lines in description produce whitespace-only lines in YAML frontmatter

### DIFF
--- a/internal/tmplfuncs/tmplfuncs.go
+++ b/internal/tmplfuncs/tmplfuncs.go
@@ -10,7 +10,13 @@ import (
 )
 
 func PrefixLines(prefix, text string) string {
-	return prefix + strings.Join(strings.Split(text, "\n"), "\n"+prefix)
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = prefix + line
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func CodeFile(format, file string) (string, error) {

--- a/internal/tmplfuncs/tmplfuncs_test.go
+++ b/internal/tmplfuncs/tmplfuncs_test.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package tmplfuncs
+
+import (
+	"testing"
+)
+
+func TestPrefixLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		prefix   string
+		text     string
+		expected string
+	}{
+		{
+			name:     "single line",
+			prefix:   "  ",
+			text:     "hello",
+			expected: "  hello",
+		},
+		{
+			name:     "multiple lines",
+			prefix:   "  ",
+			text:     "line1\nline2",
+			expected: "  line1\n  line2",
+		},
+		{
+			name:     "blank line between content produces no whitespace-only line",
+			prefix:   "  ",
+			text:     "line1\n\nline3",
+			expected: "  line1\n\n  line3",
+		},
+		{
+			name:     "multiple consecutive blank lines",
+			prefix:   "  ",
+			text:     "line1\n\n\nline4",
+			expected: "  line1\n\n\n  line4",
+		},
+		{
+			name:     "empty string",
+			prefix:   "  ",
+			text:     "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := PrefixLines(tc.prefix, tc.text)
+			if result != tc.expected {
+				t.Errorf("PrefixLines(%q, %q)\ngot:  %q\nwant: %q", tc.prefix, tc.text, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a provider resource's `Description` (or `MarkdownDescription`) contains blank lines — for example, surrounding a code fence — the generated YAML frontmatter ends up with whitespace-only lines (`  `, two spaces) instead of genuinely blank lines.

## Root cause

`PrefixLines` in `internal/tmplfuncs/tmplfuncs.go` was implemented as:

```go
return prefix + strings.Join(strings.Split(text, "\n"), "\n"+prefix)
```

`strings.Split` produces an empty string `""` for each blank line. `strings.Join` then inserts `"\n" + prefix` before that empty string, yielding a line that is just the prefix (e.g. `"  "`) with no content.

The `prefixlines "  "` template filter is used in the YAML frontmatter block scalar in all four default templates (resource, data source, function, action):

```
description: |-
{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
```

So any blank line in a provider description becomes a whitespace-only line in the generated `docs/` output.

## Fix

Skip adding the prefix when the line is empty:

```go
lines := strings.Split(text, "\n")
for i, line := range lines {
    if line != "" {
        lines[i] = prefix + line
    }
}
return strings.Join(lines, "\n")
```

## Tests

Added `internal/tmplfuncs/tmplfuncs_test.go` with unit tests for `PrefixLines`, including the blank-line regression case. The failing test case with the old implementation:

- Input: `"line1\n\nline3"`, prefix `"  "`
- Old output: `"  line1\n  \n  line3"` (middle line is `"  "`, two spaces)
- New output: `"  line1\n\n  line3"` (middle line is empty)

The existing `TestRenderStringTemplate` in `internal/provider/template_test.go` continues to pass unchanged.