### PR TITLE
Correct self-referential cmpenv in migrate acceptance test scripts

### DIFF
--- a/cmd/tfplugindocs/testdata/scripts/schema-json/migrate/time_provider_idempotency.txtar
+++ b/cmd/tfplugindocs/testdata/scripts/schema-json/migrate/time_provider_idempotency.txtar
@@ -20,7 +20,7 @@ cmpenv templates/resources/static.md.tmpl exp-templates/resources/static.md.tmpl
 cmpenv templates/ephemeral-resources/ephemeral_static.md.tmpl exp-templates/ephemeral-resources/ephemeral_static.md.tmpl
 
 # Check generated example files
-cmpenv examples/example_1.tf examples/example_1.tf
+cmpenv examples/example_1.tf exp-examples/example_1.tf
 
 cmpenv examples/functions/rfc3339_parse/example_1.tf exp-examples/functions/rfc3339_parse/example_1.tf
 

--- a/cmd/tfplugindocs/testdata/scripts/schema-json/migrate/time_provider_success_docs_website.txtar
+++ b/cmd/tfplugindocs/testdata/scripts/schema-json/migrate/time_provider_success_docs_website.txtar
@@ -21,7 +21,7 @@ cmpenv templates/list-resources/example.md.tmpl exp-templates/list-resources/exa
 cmpenv templates/state-stores/example.md.tmpl exp-templates/state-stores/example.md.tmpl
 
 # Check generated example files
-cmpenv examples/example_1.tf examples/example_1.tf
+cmpenv examples/example_1.tf exp-examples/example_1.tf
 
 cmpenv examples/functions/rfc3339_parse/example_1.tf exp-examples/functions/rfc3339_parse/example_1.tf
 

--- a/cmd/tfplugindocs/testdata/scripts/schema-json/migrate/time_provider_success_docs_website_with_prefix.txtar
+++ b/cmd/tfplugindocs/testdata/scripts/schema-json/migrate/time_provider_success_docs_website_with_prefix.txtar
@@ -21,7 +21,7 @@ cmpenv templates/list-resources/example.md.tmpl exp-templates/list-resources/exa
 cmpenv templates/state-stores/example.md.tmpl exp-templates/state-stores/example.md.tmpl
 
 # Check generated example files
-cmpenv examples/example_1.tf examples/example_1.tf
+cmpenv examples/example_1.tf exp-examples/example_1.tf
 
 cmpenv examples/functions/rfc3339_parse/example_1.tf exp-examples/functions/rfc3339_parse/example_1.tf
 

--- a/cmd/tfplugindocs/testdata/scripts/schema-json/migrate/time_provider_success_legacy_website.txtar
+++ b/cmd/tfplugindocs/testdata/scripts/schema-json/migrate/time_provider_success_legacy_website.txtar
@@ -21,7 +21,7 @@ cmpenv templates/list-resources/example.md.tmpl exp-templates/list-resources/exa
 cmpenv templates/state-stores/example.md.tmpl exp-templates/state-stores/example.md.tmpl
 
 # Check generated example files
-cmpenv examples/example_1.tf examples/example_1.tf
+cmpenv examples/example_1.tf exp-examples/example_1.tf
 
 cmpenv examples/functions/rfc3339_parse/example_1.tf exp-examples/functions/rfc3339_parse/example_1.tf
 

--- a/cmd/tfplugindocs/testdata/scripts/schema-json/migrate/time_provider_success_legacy_website_with_prefix.txtar
+++ b/cmd/tfplugindocs/testdata/scripts/schema-json/migrate/time_provider_success_legacy_website_with_prefix.txtar
@@ -21,7 +21,7 @@ cmpenv templates/list-resources/example.md.tmpl exp-templates/list-resources/exa
 cmpenv templates/state-stores/example.md.tmpl exp-templates/state-stores/example.md.tmpl
 
 # Check generated example files
-cmpenv examples/example_1.tf examples/example_1.tf
+cmpenv examples/example_1.tf exp-examples/example_1.tf
 
 cmpenv examples/functions/rfc3339_parse/example_1.tf exp-examples/functions/rfc3339_parse/example_1.tf
 


### PR DESCRIPTION
## Related Issue

Fixes CI errors for PR #611 and #612 

## Description

The CI was failing because 5 `txtar` test scripts under `testdata/scripts/schema-json/migrate/` were comparing `examples/example_1.tf` against itself instead of against the expected `exp-examples/example_1.tf`. This caused all `Test_SchemaJson_MigrateAcceptanceTests` subtests to fail on Linux/macOS with:

```
FAIL: testdata/scripts/schema-json/migrate/time_provider_idempotency.txtar:23: cmp: cannot compare a file against itself
```

Tests:

- `time_provider_idempotency`
- `time_provider_success_legacy_website`
- `time_provider_success_legacy_website_with_prefix`
- `time_provider_success_docs_website`
- `time_provider_success_docs_website_with_prefix`

## Change

```diff
-cmpenv examples/example_1.tf examples/example_1.tf
+cmpenv examples/example_1.tf exp-examples/example_1.tf
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No